### PR TITLE
[SITE-4992]Remove delete form for pantheon document

### DIFF
--- a/pantheon_content_publisher.links.contextual.yml
+++ b/pantheon_content_publisher.links.contextual.yml
@@ -2,9 +2,3 @@ entity.pantheon_document.edit_form:
   route_name: entity.pantheon_document.edit_form
   group: pantheon_document
   title: 'Edit'
-
-entity.pantheon_document.delete_form:
-  route_name: entity.pantheon_document.delete_form
-  group: pantheon_document
-  title: 'Delete'
-  weight: 10

--- a/pantheon_content_publisher.links.task.yml
+++ b/pantheon_content_publisher.links.task.yml
@@ -6,11 +6,6 @@ entity.pantheon_document.edit_form:
   title: 'Edit'
   route_name: entity.pantheon_document.edit_form
   base_route: entity.pantheon_document.canonical
-entity.pantheon_document.delete_form:
-  title: 'Delete'
-  route_name: entity.pantheon_document.delete_form
-  base_route: entity.pantheon_document.canonical
-  weight: 10
 entity.pantheon_document.collection:
   title: 'Pantheon Documents'
   route_name: entity.pantheon_document.collection


### PR DESCRIPTION
Removed the unwanted delete form/tab for pantheon document in drupal interface.
Fixes the issue `Symfony\Component\Routing\Exception\RouteNotFoundException: Route "entity.pantheon_document.delete_form" does not exist. in Drupal\Core\Routing\RouteProvider->getRouteByName() (line 214 of core/lib/Drupal/Core/Routing/RouteProvider.php). (for anonymous users)
`


<img width="837" height="528" alt="Screenshot 2025-08-12 at 7 32 18 PM" src="https://github.com/user-attachments/assets/440ce4d8-e25b-424e-8f69-6e366a13857e" />





