### PR TITLE
[SITE-4985] Fix issue with rendering image and description metadata

### DIFF
--- a/src/PantheonDocumentStorage.php
+++ b/src/PantheonDocumentStorage.php
@@ -55,14 +55,13 @@ class PantheonDocumentStorage extends ContentEntityStorageBase implements Panthe
       if (!$collection = $this->collectionStorage->load($collection_name)) {
         continue;
       }
-      $pantheon_data = $collection->getGraphQL()->getArticle($pantheon_id);
-      $metadata = $pantheon_data['metadata'] ?? [];
       try {
         $pantheon_data = $collection->getGraphQL()->getArticle($pantheon_id);
       }
       catch (GraphQLException $e) {
         continue;
       }
+      $metadata = $pantheon_data['metadata'] ?? [];
       $drupal_data = $this->pantheonContentPublisherConverter->pantheonMetadataToDrupalRecord($pantheon_data);
       $drupal_data += [
         'id' => $id,

--- a/src/PantheonDocumentStorage.php
+++ b/src/PantheonDocumentStorage.php
@@ -55,7 +55,6 @@ class PantheonDocumentStorage extends ContentEntityStorageBase implements Panthe
       if (!$collection = $this->collectionStorage->load($collection_name)) {
         continue;
       }
-
       $pantheon_data = $collection->getGraphQL()->getArticle($pantheon_id);
       $metadata = $pantheon_data['metadata'] ?? [];
 

--- a/src/PantheonDocumentStorage.php
+++ b/src/PantheonDocumentStorage.php
@@ -57,14 +57,12 @@ class PantheonDocumentStorage extends ContentEntityStorageBase implements Panthe
       }
       $pantheon_data = $collection->getGraphQL()->getArticle($pantheon_id);
       $metadata = $pantheon_data['metadata'] ?? [];
-
       try {
         $pantheon_data = $collection->getGraphQL()->getArticle($pantheon_id);
       }
       catch (GraphQLException $e) {
         continue;
       }
-
       $drupal_data = $this->pantheonContentPublisherConverter->pantheonMetadataToDrupalRecord($pantheon_data);
       $drupal_data += [
         'id' => $id,

--- a/src/PantheonDocumentStorage.php
+++ b/src/PantheonDocumentStorage.php
@@ -56,6 +56,7 @@ class PantheonDocumentStorage extends ContentEntityStorageBase implements Panthe
         continue;
       }
       $pantheon_data = $collection->getGraphQL()->getArticle($pantheon_id);
+      $metadata = $pantheon_data['metadata'] ?? [];
       $drupal_data = $this->pantheonContentPublisherConverter->pantheonMetadataToDrupalRecord($pantheon_data);
       $drupal_data += [
         'id' => $id,
@@ -63,7 +64,8 @@ class PantheonDocumentStorage extends ContentEntityStorageBase implements Panthe
         'content' => $pantheon_data['content'],
         'title' => $pantheon_data['title'],
         'slug' => $pantheon_data['slug'],
-        'image' => $pantheon_data['image'],
+        'description' => $metadata['description'] ?? '',
+        'image' => $metadata['image'] ?? '',
       ];
       // Our main concerns are
       // 1) search API and search_api_entity_update() contains the entirety

--- a/tests/src/Kernel/PantheonDocumentTestTrait.php
+++ b/tests/src/Kernel/PantheonDocumentTestTrait.php
@@ -204,11 +204,11 @@ trait PantheonDocumentTestTrait {
         'A text meta' => 'Plain text field test contents',
         'A textarea meta' => 'textarea test contents',
         'description' => 'A random description',
+        'image' => 'test-image',
       ],
       'content' => $this->articleContent,
       'title' => 'test title',
       'slug' => 'test-slug',
-      'image' => 'test-image',
     ];
   }
 


### PR DESCRIPTION
The image and description metadata fields added in the PCC are not rendered correctly in the drupal, and the image field repeatedly triggers an error.

“Warning: Undefined array key "image" in Drupal\pantheon_content_publisher\PantheonDocumentStorage->doLoadMultiple() (line 66 of /code/web/modules/contrib/pantheon_content_publisher/src/PantheonDocumentStorage.php)”

This PR addresses the issue.