### PR TITLE
[SITE-5184] Fix title and description for content publisher collections

### DIFF
--- a/pantheon_content_publisher.links.menu.yml
+++ b/pantheon_content_publisher.links.menu.yml
@@ -1,7 +1,7 @@
 entity.pantheon_document_collection.overview:
-  title: Pantheon content publisher collections
+  title: Pantheon Content Publisher collections
   parent: system.admin_structure
-  description: 'List of pantheon content publisher collections to extend site functionality.'
+  description: 'Connect and manage Pantheon Content Publisher collections.'
   route_name: entity.pantheon_document_collection.collection
 
 entity.pantheon_document.collection:


### PR DESCRIPTION
As per Silvy Yang's suggestion, changed the text from

-Pantheon content publisher collections → Pantheon Content Publisher collections
-List of pantheon content publisher collections to extend site functionality. → Connect and manage Pantheon Content Publisher collections.

<img width="738" height="406" alt="Screenshot 2025-09-10 at 7 31 51 PM" src="https://github.com/user-attachments/assets/bf7f35a6-64fc-4160-9ec7-e8e09c9b77fd" />
