### PR TITLE
[SITE-5183] Update name and description of Pantheon Content Publisher module info

### DIFF
--- a/pantheon_content_publisher.info.yml
+++ b/pantheon_content_publisher.info.yml
@@ -1,7 +1,7 @@
 name: 'Pantheon Content Publisher'
 type: module
 description: 'Pantheon Content Publisher integration.'
-package: 'pantheon'
+package: 'Pantheon'
 core_version_requirement: ^10 || ^11
 dependencies:
   - search_api:search_api (>= 8.x-1.20)

--- a/pantheon_content_publisher.info.yml
+++ b/pantheon_content_publisher.info.yml
@@ -1,6 +1,6 @@
-name: 'Pantheon content publisher'
+name: 'Pantheon Content Publisher'
 type: module
-description: 'Pantheon content publisher integration.'
+description: 'Pantheon Content Publisher integration.'
 package: 'pantheon'
 core_version_requirement: ^10 || ^11
 dependencies:


### PR DESCRIPTION
As per Silvy Yang's suggestion changed test from 
- pantheon → Pantheon (Package)
- Pantheon content publisher → Pantheon Content Publisher (Module name)
- Pantheon content publisher integration → Pantheon Content Publisher integration (Module Description)
