### PR TITLE
[SITE-5223] Fix duplicate creation of metadata fields in search index

### DIFF
--- a/src/Entity/PantheonDocumentCollection.php
+++ b/src/Entity/PantheonDocumentCollection.php
@@ -139,6 +139,7 @@ class PantheonDocumentCollection extends ConfigEntityBase implements PantheonDoc
       }
     }
     // By now only the new fields remain.
+    $fields = [];
     $prefix = 'field.storage.pantheon_document.';
     $field_storage_ids = array_flip(\Drupal::service('config.storage')->listAll($prefix));
     $field_storage_ids[$prefix . 'content'] = TRUE;


### PR DESCRIPTION
This fix suggested by Chx will prevent creation of duplicates of metafields in search index.
<img width="1460" height="507" alt="Screenshot 2025-09-12 at 8 50 03 PM" src="https://github.com/user-attachments/assets/ffcf5f7a-3efa-4346-8f3d-0cf29e3a04d6" />
