### PR TITLE
[Site-5185] Fix labels/text for content publisher collection

### DIFF
--- a/pantheon_content_publisher.info.yml
+++ b/pantheon_content_publisher.info.yml
@@ -1,7 +1,7 @@
 name: 'Pantheon content publisher'
 type: module
 description: 'Pantheon content publisher integration.'
-package: 'pantheon'
+package: 'Pantheon'
 core_version_requirement: ^10 || ^11
 dependencies:
   - search_api:search_api (>= 8.x-1.20)

--- a/pantheon_content_publisher.links.action.yml
+++ b/pantheon_content_publisher.links.action.yml
@@ -1,6 +1,6 @@
 entity.pantheon_document_collection.add_form:
   route_name: 'entity.pantheon_document_collection.add_form'
-  title: 'Add pantheon content publisher collection'
+  title: 'Connect a new collection'
   appears_on:
     - entity.pantheon_document_collection.collection
 

--- a/pantheon_content_publisher.routing.yml
+++ b/pantheon_content_publisher.routing.yml
@@ -2,7 +2,7 @@ entity.pantheon_document_collection.collection:
   path: '/admin/structure/pantheon-content-publisher-collection'
   defaults:
     _entity_list: 'pantheon_document_collection'
-    _title: 'Pantheon content publisher collection configuration'
+    _title: 'Pantheon Content Publisher collections'
   requirements:
     _permission: 'administer pantheon_document_collection'
 

--- a/src/Entity/PantheonDocumentCollection.php
+++ b/src/Entity/PantheonDocumentCollection.php
@@ -27,7 +27,7 @@ use Drupal\search_api\Utility\FieldsHelperInterface;
  *   label = @Translation("Pantheon document collection"),
  *   label_collection = @Translation("Pantheon document collections"),
  *   label_singular = @Translation("pantheon document collection"),
- *   label_plural = @Translation("pantheon document collections"),
+ *   label_plural = @Translation("Pantheon Document collections"),
  *   label_count = @PluralTranslation(
  *     singular = "@count pantheon document collection",
  *     plural = "@count pantheon document collections",

--- a/src/PantheonDocumentCollectionListBuilder.php
+++ b/src/PantheonDocumentCollectionListBuilder.php
@@ -16,8 +16,8 @@ class PantheonDocumentCollectionListBuilder extends ConfigEntityListBuilder {
    * {@inheritdoc}
    */
   public function buildHeader(): array {
-    $header['label'] = $this->t('Label');
-    $header['id'] = $this->t('Machine name');
+    $header['label'] = $this->t('Collection name');
+    $header['id'] = $this->t('Collection ID');
     $header['status'] = $this->t('Status');
     return $header + parent::buildHeader();
   }


### PR DESCRIPTION
This PR will apply the following changes suggested by Product Designer.

[Title] Pantheon content publisher collection configuration → Pantheon Content Publisher collections

[Button] Add pantheon content publisher collection → Connect a new collection

[Table]Label → Collection name

[Table]Machine name → Collection ID

[Table empty state]There are no pantheon document collections yet. → There are no Pantheon Content Publisher collections yet.

<img width="1401" height="498" alt="Screenshot 2025-09-17 at 5 38 08 PM" src="https://github.com/user-attachments/assets/1a8fd61d-280e-4314-95e5-4a464ddc17a8" />
