### PR TITLE
[SITE-5287] Fix Drupal 11 TypeError with null values in select options

### DIFF
--- a/pantheon_content_publisher.module
+++ b/pantheon_content_publisher.module
@@ -114,7 +114,11 @@ function pantheon_content_publisher_form_key_add_form_alter(&$form) {
  * Implements hook_element_info_alter().
  */
 function pantheon_content_publisher_element_info_alter(array &$info) {
-  unset($info['key_select']['#empty_option']);
+  // Drupal 11 compatibility: Keep empty option but set it to a safe string value
+  // to prevent TypeError when Html::escape() receives null values.
+  if (isset($info['key_select']['#empty_option'])) {
+    $info['key_select']['#empty_option'] = t('- Select a key -');
+  }
 }
 
 /**

--- a/src/Entity/PantheonDocumentCollection.php
+++ b/src/Entity/PantheonDocumentCollection.php
@@ -289,8 +289,8 @@ class PantheonDocumentCollection extends ConfigEntityBase implements PantheonDoc
     $options = $definition->getThirdPartySetting('pantheon_content_publisher', 'pantheon_data')['options'];
     // Drupal 11 compatibility: Filter out null values to prevent TypeError
     // when Html::escape() is called on select option labels.
-    $options = array_filter($options, function($value) {
-      return $value !== null && $value !== '';
+    $options = array_filter($options, function ($value) {
+      return $value !== NULL && $value !== '';
     });
     return $options ? array_combine($options, $options) : [];
   }

--- a/src/Entity/PantheonDocumentCollection.php
+++ b/src/Entity/PantheonDocumentCollection.php
@@ -287,7 +287,12 @@ class PantheonDocumentCollection extends ConfigEntityBase implements PantheonDoc
   public static function getPantheonListOptions(FieldStorageConfigInterface $definition, $entity, &$cacheable): array {
     $cacheable = TRUE;
     $options = $definition->getThirdPartySetting('pantheon_content_publisher', 'pantheon_data')['options'];
-    return array_combine($options, $options);
+    // Drupal 11 compatibility: Filter out null values to prevent TypeError
+    // when Html::escape() is called on select option labels.
+    $options = array_filter($options, function($value) {
+      return $value !== null && $value !== '';
+    });
+    return $options ? array_combine($options, $options) : [];
   }
 
   /**


### PR DESCRIPTION
This commit addresses #22 which is a Drupal 11 compatibility issue where the module passes null values to form select options, causing a TypeError in Html::escape() which now enforces strict type checking. 

Changes:
- pantheon_content_publisher.module: Modified element_info_alter hook to set a safe string value for empty_option instead of unsetting it
- PantheonDocumentCollection.php: Added null filtering in getPantheonListOptions() to prevent null values from being passed to array_combine() and subsequently to Html::escape()

The error occurred because:
1. Drupal 11 enforces stricter type checking than previous versions
2. Html::escape() now requires a string parameter but was receiving null
3. The module was unsetting empty_option which could result in null values

This fix ensures compatibility with Drupal 11's stricter type system while maintaining the intended functionality of the module.