### PR TITLE
[SITE-5268] Prevent save() on int error in EntityQueueWorker

### DIFF
--- a/src/EventSubscriber/QueueRunner.php
+++ b/src/EventSubscriber/QueueRunner.php
@@ -22,7 +22,7 @@ class QueueRunner implements EventSubscriberInterface {
     if (!file_exists($drush)) {
       return;
     }
-    $process = new Process([$drush, 'queue-run', 'pantheon_content_publisher_entity_save']);
+    $process = new Process([$drush, 'queue-run', 'pantheon_content_publisher_entity']);
     $process->setTimeout(0);
     $process->run();
   }

--- a/src/Plugin/QueueWorker/EntityQueueWorker.php
+++ b/src/Plugin/QueueWorker/EntityQueueWorker.php
@@ -10,7 +10,7 @@ use Drupal\Core\Queue\QueueWorkerBase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Defines 'pantheon_content_publisher_entity_save' queue worker.
+ * Defines 'pantheon_content_publisher_entity' queue worker.
  *
  * @QueueWorker(
  *   id = "pantheon_content_publisher_entity",

--- a/src/Plugin/QueueWorker/EntityQueueWorker.php
+++ b/src/Plugin/QueueWorker/EntityQueueWorker.php
@@ -48,13 +48,14 @@ class EntityQueueWorker extends QueueWorkerBase implements ContainerFactoryPlugi
     $entity_type_id = $data['entity_type'];
     $entity = $this->entityTypeManager
       ->getStorage($entity_type_id)
-      ->load($data['entity_id'])
-      ->save();
-    if (empty($data['delete'])) {
-      $entity->save();
-    }
-    else {
-      $entity->delete();
+      ->load($data['entity_id']);
+    if ($entity) {
+      if (empty($data['delete'])) {
+        $entity->save();
+      }
+      else {
+        $entity->delete();
+      }
     }
     $index_storage = $this->entityTypeManager->getStorage('search_api_index');
     $datasource_id = "entity:$entity_type_id";


### PR DESCRIPTION
This PR address the issue 
```
  Error: Call to a member function save() on int in Drupal\pantheon_content_publisher\Plugin\QueueWorker\EntityQ
  ueueWorker->processItem() (line 54 of /code/web/modules/contrib/pantheon_content_publisher/src/Plugin/QueueWorker/Entity
  QueueWorker.php) #0 /code/vendor/drush/drush/src/Commands/core/QueueCommands.php(104): 
```