### PR TITLE
[SITE-5268]Fix issue with datasource count on search API status

### DIFF
--- a/src/Plugin/search_api/datasource/PantheonDocumentDatasource.php
+++ b/src/Plugin/search_api/datasource/PantheonDocumentDatasource.php
@@ -49,7 +49,7 @@ class PantheonDocumentDatasource extends ContentEntity {
       if ($bundles) {
         $enabled_bundles = array_unique(array_merge($bundles, $enabled_bundles));
       }
-      $all_bundles = $this->getEntityBundles();
+      $all_bundles = array_keys($this->getEntityBundles());
       $bundles_for_query = count($enabled_bundles) < count($all_bundles) ? $enabled_bundles : $all_bundles;
     }
     // Page is across all collections in this index.


### PR DESCRIPTION
This fix addresses the issue 
Warning: array_flip(): Can only flip string and integer values, entry skipped in Drupal\Core\Entity\EntityStorageBase->loadMultiple() /code/web/modules/contrib/pantheon_content_publisher/src/Plugin/search_api/datasource/PantheonDocumentDatasource.php(68): Drupal\Core\Entity\EntityBase::loadMultiple()
#5 /code/web/modules/contrib/search_api/src/Plugin/search_api/datasource/ContentEntity.php(752): Drupal\pantheon_content_publisher\Plugin\search_api\datasource\PantheonDocumentDatasource->getPartialItemIds()
#6 /code/web/modules/contrib/search_api/src/Task/IndexTaskManager.php(127): Drupal\search_api\Plugin\search_api\datasource\ContentEntity->getItemIds()
#7 [internal function]: Drupal\search_api\Task\IndexTaskManager->trackItems()
