### PR TITLE
[SITE-5321] Add null check for document in processItem()

### DIFF
--- a/src/Plugin/QueueWorker/Images.php
+++ b/src/Plugin/QueueWorker/Images.php
@@ -65,7 +65,9 @@ class Images extends QueueWorkerBase implements ContainerFactoryPluginInterface 
    * {@inheritdoc}
    */
   public function processItem($data): void {
-    $document = $this->pantheonContentPublisherStorage->load($data);
+    if (!$document = $this->pantheonContentPublisherStorage->load($data)) {
+      return;
+    }
     $content = $document->get('content');
     if ($content->isEmpty() || !($pantheon_files = static::getImageData($content->value))) {
       return;


### PR DESCRIPTION
This PR addresses the error
`Error: Call to a member function get() on null in Drupal\pantheon_content_publisher\Plugin\QueueWorker\Images->processItem() (line 69 of /code/web/modules/contrib/pantheon_content_publisher/src/Plugin/QueueWorker/Images.php)`