### PR TITLE
SITE-5268: Ensure index insertion only happens when publishing.

### DIFF
--- a/src/PantheonDocumentStorage.php
+++ b/src/PantheonDocumentStorage.php
@@ -14,8 +14,6 @@ use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
-use Drupal\Core\KeyValueStore\KeyValueFactoryInterface;
-use Drupal\Core\KeyValueStore\KeyValueStoreInterface;
 use Drupal\pantheon_content_publisher\Entity\PantheonDocument;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -26,8 +24,6 @@ class PantheonDocumentStorage extends ContentEntityStorageBase implements Panthe
 
   const SEPARATOR = '.';
 
-  protected KeyValueStoreInterface $seenStore;
-
   public function __construct(
     EntityTypeInterface $entity_type,
     EntityFieldManagerInterface $entity_field_manager,
@@ -36,9 +32,7 @@ class PantheonDocumentStorage extends ContentEntityStorageBase implements Panthe
     EntityTypeBundleInfoInterface $entity_type_bundle_info,
     protected EntityStorageInterface $collectionStorage,
     protected PantheonContentPublisherConverter $pantheonContentPublisherConverter,
-    KeyValueFactoryInterface $keyValueFactory,
   ) {
-    $this->seenStore = $keyValueFactory->get('pantheon_document.seen');
     parent::__construct($entity_type, $entity_field_manager, $cache, $memory_cache, $entity_type_bundle_info);
   }
 
@@ -50,8 +44,7 @@ class PantheonDocumentStorage extends ContentEntityStorageBase implements Panthe
       $container->get('entity.memory_cache'),
       $container->get('entity_type.bundle.info'),
       $container->get('entity_type.manager')->getStorage('pantheon_document_collection'),
-      $container->get('pantheon_content_publisher.converter'),
-      $container->get('keyvalue')
+      $container->get('pantheon_content_publisher.converter')
     );
   }
 
@@ -71,9 +64,6 @@ class PantheonDocumentStorage extends ContentEntityStorageBase implements Panthe
       $drupal_data = $this->pantheonContentPublisherConverter
         ->convert($pantheon_data, $collection_name, $id);
       $document = PantheonDocument::create($drupal_data);
-      if ($this->seenStore->setIfNotExists($id, 1)) {
-        $this->invokeHook('insert', $document);
-      }
       $entities[$id] = $document->enforceIsNew(FALSE);
     }
     return $entities;
@@ -135,13 +125,6 @@ class PantheonDocumentStorage extends ContentEntityStorageBase implements Panthe
   public static function getEntityId(string|PantheonDocumentCollectionInterface $collection, string $pantheon_id): string {
     return ($collection instanceof PantheonDocumentCollectionInterface ? $collection->id() : $collection) . self::SEPARATOR .
       $pantheon_id;
-  }
-
-  protected function doDelete($entities) {
-    parent::doDelete($entities);
-    foreach ($entities as $entity) {
-      $this->seenStore->delete($entity->id());
-    }
   }
 
 }

--- a/src/Plugin/QueueWorker/EntityQueueWorker.php
+++ b/src/Plugin/QueueWorker/EntityQueueWorker.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Drupal\pantheon_content_publisher\Plugin\QueueWorker;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\KeyValueStore\KeyValueFactoryInterface;
+use Drupal\Core\KeyValueStore\KeyValueStoreInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Queue\QueueWorkerBase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -20,12 +22,16 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class EntityQueueWorker extends QueueWorkerBase implements ContainerFactoryPluginInterface {
 
+  protected KeyValueStoreInterface $seenStore;
+
   public function __construct(
     array $configuration,
     $plugin_id,
     $plugin_definition,
     protected EntityTypeManagerInterface $entityTypeManager,
+    KeyValueFactoryInterface $keyValueFactory,
   ) {
+    $this->seenStore = $keyValueFactory->get('pantheon_document.seen');
     parent::__construct($configuration, $plugin_id, $plugin_definition);
   }
 
@@ -38,6 +44,7 @@ class EntityQueueWorker extends QueueWorkerBase implements ContainerFactoryPlugi
       $plugin_id,
       $plugin_definition,
       $container->get('entity_type.manager'),
+      $container->get('keyvalue')
     );
   }
 
@@ -50,6 +57,11 @@ class EntityQueueWorker extends QueueWorkerBase implements ContainerFactoryPlugi
 
     if (empty($data['delete'])) {
       $entity = $storage->load($data['entity_id']);
+      if ($this->seenStore->setIfNotExists($entity->id(), 1)) {
+        (new \ReflectionObject($storage))
+          ->getMethod('invokeHook')
+          ->invoke($storage, 'insert', $entity);
+      }
       $entity->save();
     }
     else {
@@ -60,13 +72,7 @@ class EntityQueueWorker extends QueueWorkerBase implements ContainerFactoryPlugi
       ]);
       $entity->enforceIsNew(FALSE);
       $entity->delete();
-    }
-    $index_storage = $this->entityTypeManager->getStorage('search_api_index');
-    $datasource_id = "entity:$entity_type_id";
-    // Querying for datasource_id is possible, however the default config
-    // entity query implementation loads all indexes anyways.
-    foreach ($index_storage->loadMultiple() as $index) {
-      $index->indexItems(-1, $datasource_id);
+      $this->seenStore->delete($entity->id());
     }
   }
 


### PR DESCRIPTION
Replaces PR #30.

This change was worked on with Chx and confirmed working in a pantheon.io multidev. It protects against a deleted document being re-added to the index when solr returns stale results to Drupal.