### PR TITLE
[SITE-5346] Explicitly save field storage during custom metadata field creation

### DIFF
--- a/src/Entity/PantheonDocumentCollection.php
+++ b/src/Entity/PantheonDocumentCollection.php
@@ -241,6 +241,7 @@ class PantheonDocumentCollection extends ConfigEntityBase implements PantheonDoc
         // it twice.
         $field_storage->setSetting('allowed_values_function', static::class . '::getPantheonListOptions');
       }
+      $field_storage->save();
     }
     $data = [
       'field_name' => $drupal_field_name,


### PR DESCRIPTION
**Issue**
Creating a custom metadata field for a collection results in partial creation of the field. The field is created without saving field storage, which breaks the corresponding Search API index and triggers the error:

`Attempted to create, modify or delete an instance of a field with <field_name> notes on entity type pantheon_document when the field storage does not exist.`

_This bug occurs frequently, though there are instances where the custom metafield gets created successfully with field storage in the Drupal website._

**Solution**

This PR adds the necessary `$field_storage->save()` call to guarantee the creation of field storage.

Jira link
https://getpantheon.atlassian.net/browse/SITE-5346