### PR TITLE
[SITE-5355] Fix issue with adding pantheon document reference field

### DIFF
--- a/src/Entity/PantheonDocument.php
+++ b/src/Entity/PantheonDocument.php
@@ -57,6 +57,7 @@ use Drupal\pantheon_content_publisher\PantheonDocumentInterface;
  *     "edit-form" = "/pantheon-content-publisher/{pantheon_document}/edit",
  *   },
  *   bundle_entity_type = "pantheon_document_collection",
+ *   common_reference_target = TRUE,
  * )
  */
 class PantheonDocument extends ContentEntityBase implements PantheonDocumentInterface {

--- a/src/Plugin/EntityReferenceSelection/PantheonDocumentSelection.php
+++ b/src/Plugin/EntityReferenceSelection/PantheonDocumentSelection.php
@@ -3,6 +3,7 @@
 namespace Drupal\pantheon_content_publisher\Plugin\EntityReferenceSelection;
 
 use Drupal\Core\Entity\Plugin\EntityReferenceSelection\DefaultSelection;
+use Drupal\Core\Entity\Query\QueryInterface;
 
 /**
  * Provides a selection plugin for Pantheon documents.
@@ -19,7 +20,7 @@ class PantheonDocumentSelection extends DefaultSelection {
   /**
    * {@inheritdoc}
    */
-   protected function buildEntityQuery($match = NULL, $match_operator = 'CONTAINS'): QueryInterface {
+  protected function buildEntityQuery($match = NULL, $match_operator = 'CONTAINS'): QueryInterface {
     $configuration = $this->getConfiguration();
     $target_type = 'pantheon_document';
     $entity_type = $this->entityTypeManager->getDefinition($target_type);

--- a/src/Plugin/EntityReferenceSelection/PantheonDocumentSelection.php
+++ b/src/Plugin/EntityReferenceSelection/PantheonDocumentSelection.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Drupal\pantheon_content_publisher\Plugin\EntityReferenceSelection;
+
+use Drupal\Core\Entity\Plugin\EntityReferenceSelection\DefaultSelection;
+
+/**
+ * Provides a selection plugin for Pantheon documents.
+ *
+ * @EntityReferenceSelection(
+ *   id = "pantheon_document_selection",
+ *   label = @Translation("Pantheon Document Selection"),
+ *   group = "default",
+ *   weight = 0
+ * )
+ */
+class PantheonDocumentSelection extends DefaultSelection {
+
+  /**
+   * {@inheritdoc}
+   */
+   protected function buildEntityQuery($match = NULL, $match_operator = 'CONTAINS'): QueryInterface {
+    $configuration = $this->getConfiguration();
+    $target_type = 'pantheon_document';
+    $entity_type = $this->entityTypeManager->getDefinition($target_type);
+
+    /** @var \Drupal\Core\Entity\Query\QueryInterface $query */
+    $query = $this->entityTypeManager->getStorage($target_type)->getQuery();
+    $query->accessCheck(TRUE);
+
+    if (isset($match) && $label_key = $entity_type->getKey('label')) {
+      $query->condition($label_key, $match, $match_operator);
+    }
+
+    $collection_ids = $configuration['target_bundles'] ?? [];
+    if (!empty($collection_ids)) {
+      $query->condition('collection', $collection_ids, 'IN');
+    }
+
+    // Add entity-access tag.
+    $query->addTag($target_type . '_access');
+    $query->addTag('entity_reference');
+    $query->addMetaData('entity_reference_selection_handler', $this);
+
+    // Add the sort option.
+    if (!empty($configuration['sort']) && $configuration['sort']['field'] !== '_none') {
+      $query->sort($configuration['sort']['field'], $configuration['sort']['direction']);
+    }
+
+    return $query;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateReferenceableEntities(array $ids): array {
+    return parent::validateReferenceableEntities($ids);
+  }
+
+}

--- a/src/Plugin/EntityReferenceSelection/PantheonDocumentSelection.php
+++ b/src/Plugin/EntityReferenceSelection/PantheonDocumentSelection.php
@@ -2,19 +2,21 @@
 
 namespace Drupal\pantheon_content_publisher\Plugin\EntityReferenceSelection;
 
+use Drupal\Core\Entity\Attribute\EntityReferenceSelection;
 use Drupal\Core\Entity\Plugin\EntityReferenceSelection\DefaultSelection;
 use Drupal\Core\Entity\Query\QueryInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
  * Provides a selection plugin for Pantheon documents.
- *
- * @EntityReferenceSelection(
- *   id = "pantheon_document_selection",
- *   label = @Translation("Pantheon Document Selection"),
- *   group = "default",
- *   weight = 0
- * )
  */
+#[EntityReferenceSelection(
+  id: 'default:pantheon_document',
+  label: new TranslatableMarkup('Pantheon Document Selection'),
+  entity_types: ['pantheon_document'],
+  group: 'default',
+  weight: 1
+)]
 class PantheonDocumentSelection extends DefaultSelection {
 
   /**

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -30,6 +30,7 @@ class Query extends QueryBase {
         unset($conditions[$key]);
       }
 
+      // Extract id filters to support entity reference validation and widget rendering.
       if ($condition['field'] === 'id' && in_array($condition['operator'] ?? '=', ['=', 'IN'])) {
         $target_ids = (array) $condition['value'];
         unset($conditions[$key]);
@@ -42,6 +43,7 @@ class Query extends QueryBase {
       foreach ($collection->getGraphQL()->getArticles() as $pantheon_record) {
         $key = PantheonDocumentStorage::getEntityId($collection, $pantheon_record['id']);
 
+        // Skip documents not in the target id list when specific ids are requested.
         if ($target_ids !== NULL && !in_array($key, $target_ids)) {
           continue;
         }

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -23,23 +23,33 @@ class Query extends QueryBase {
   public function execute() {
     $conditions = &$this->condition->conditions();
     $collections = NULL;
+    $target_ids = NULL;
     foreach ($conditions as $key => $condition) {
-      if ($condition['field'] === 'collection' && in_array(($condition['operator'] ?? '='), ['=', 'IN'])) {
+      if ($condition['field'] === 'collection' && in_array($condition['operator'] ?? '=', ['=', 'IN'])) {
         $collections = (array) $condition['value'];
         unset($conditions[$key]);
-        break;
+      }
+
+      if ($condition['field'] === 'id' && in_array($condition['operator'] ?? '=', ['=', 'IN'])) {
+        $target_ids = (array) $condition['value'];
+        unset($conditions[$key]);
       }
     }
+
     $collections = PantheonDocumentCollection::loadMultiple($collections);
     $records = [];
     foreach ($collections as $collection) {
       foreach ($collection->getGraphQL()->getArticles() as $pantheon_record) {
         $key = PantheonDocumentStorage::getEntityId($collection, $pantheon_record['id']);
+
+        if ($target_ids !== NULL && !in_array($key, $target_ids)) {
+            continue;
+        }
+
         $records[$key] = $this->converter->convert($pantheon_record, $collection->id());
       }
     }
 
-    // Copy-paste from
     // Drupal\Core\Entity\KeyValueStore\Query\Query::execute().
     $result = $this->condition->compile($records);
 
@@ -68,3 +78,4 @@ class Query extends QueryBase {
   }
 
 }
+

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -43,7 +43,7 @@ class Query extends QueryBase {
         $key = PantheonDocumentStorage::getEntityId($collection, $pantheon_record['id']);
 
         if ($target_ids !== NULL && !in_array($key, $target_ids)) {
-            continue;
+          continue;
         }
 
         $records[$key] = $this->converter->convert($pantheon_record, $collection->id());
@@ -78,4 +78,3 @@ class Query extends QueryBase {
   }
 
 }
-


### PR DESCRIPTION
-------
**Issue**
https://getpantheon.atlassian.net/browse/SITE-5355


Unable to add Pantheon Document as an entity reference field

 Pantheon Content Publisher uses a custom storage layer that loads documents from GraphQL rather than Drupal’s database.

And previously, the query class (src/Query/Query.php) only supported filtering by collection, which was insufficient for entity reference fields. Entity reference validation and widget rendering require querying by specific entity IDs to confirm that referenced entities exist.

**Solution**
  This PR adds:
  1. A new `PantheonDocumentSelection` plugin that properly integrates with Drupal's entity reference system
  2. Enhanced query support in `src/Query/Query.php` to filter by specific entity IDs in addition to collections
  3.  Added `common_reference_target = TRUE` in the entity type annotation, making Pantheon documents available in the standard entity reference field configuration.

  This enables users to create entity reference fields targeting Pantheon documents.

<img width="1481" height="513" alt="Screenshot 2025-12-10 at 9 38 13 AM" src="https://github.com/user-attachments/assets/42bc3697-abb2-41f5-8db4-53104e18690a" />
<img width="927" height="402" alt="Screenshot 2025-12-16 at 10 29 13 AM" src="https://github.com/user-attachments/assets/8a054fb8-a038-4704-a969-c4acd0dd1cab" />
<img width="1207" height="525" alt="Screenshot 2025-12-16 at 10 29 37 AM" src="https://github.com/user-attachments/assets/5afddbf6-3ce5-4590-a010-c955ad7b0960" />
<img width="1252" height="638" alt="Screenshot 2025-12-16 at 10 30 15 AM" src="https://github.com/user-attachments/assets/ee7cd44d-1f3e-48b6-bba7-3506436e7f49" />

