### PR TITLE
[SITE-5113] Remove hard dependency for Media Library Form API Element

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
          ],
     "require": {
         "drupal/search_api": "^1.0",
-        "drupal/media_library_form_element": "^2.1",
         "drupal/imagecache_external": "^3.0",
         "dpauli/graphql-request-builder": "^1.0",
         "drupal/key": "^1.20"

--- a/pantheon_content_publisher.info.yml
+++ b/pantheon_content_publisher.info.yml
@@ -7,3 +7,4 @@ dependencies:
   - search_api:search_api (>= 8.x-1.20)
   - imagecache_external:imagecache_external
   - key:key
+  - drupal:media

--- a/pantheon_content_publisher.info.yml
+++ b/pantheon_content_publisher.info.yml
@@ -5,6 +5,5 @@ package: 'Pantheon'
 core_version_requirement: ^10 || ^11
 dependencies:
   - search_api:search_api (>= 8.x-1.20)
-  - media_library_form_element:media_library_form_element
   - imagecache_external:imagecache_external
   - key:key

--- a/src/Form/PantheonSmartComponentForm.php
+++ b/src/Form/PantheonSmartComponentForm.php
@@ -6,6 +6,7 @@ namespace Drupal\pantheon_content_publisher\Form;
 
 use Drupal\Core\Entity\EntityForm;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\ElementInfoManagerInterface;
 use Drupal\Core\Url;
 use Drupal\pantheon_content_publisher\Entity\PantheonSmartComponent;
 
@@ -39,13 +40,17 @@ class PantheonSmartComponentForm extends EntityForm {
       '#disabled' => !$this->entity->isNew(),
     ];
 
-    $form['icon_media'] = [
-      '#type' => 'media_library',
-      '#title' => $this->t('Icon'),
-      '#allowed_bundles' => ['image'],
-      '#default_value' => $this->entity->get('icon'),
-      '#description' => t('Upload or select the icon for this component.'),
-    ];
+    // Removed hard dependency on media_library_form_element contrib module.
+    // Only add icon field if media_library form element is available.
+    if (\Drupal::service(ElementInfoManagerInterface::class)->getDefinition('media_library', FALSE)) {
+      $form['icon_media'] = [
+        '#type' => 'media_library',
+        '#title' => $this->t('Icon'),
+        '#allowed_bundles' => ['image'],
+        '#default_value' => $this->entity->get('icon'),
+        '#description' => $this->t('Upload or select the icon for this component.'),
+      ];
+    }
 
     return $form;
   }
@@ -54,11 +59,14 @@ class PantheonSmartComponentForm extends EntityForm {
    * {@inheritdoc}
    */
   public function save(array $form, FormStateInterface $form_state): int {
-    if ($mid = $form_state->getValue('icon_media')) {
-      $this->entity->set('icon', (int) $mid);
-    }
-    else {
-      $this->entity->set('icon', NULL);
+    // Only save icon if the field was present in the form.
+    if ($form_state->hasValue('icon_media')) {
+      if ($mid = $form_state->getValue('icon_media')) {
+        $this->entity->set('icon', (int) $mid);
+      }
+      else {
+        $this->entity->set('icon', NULL);
+      }
     }
     $message_args = ['%label' => $this->entity->label()];
     $result = parent::save($form, $form_state);


### PR DESCRIPTION
Drupal Content Publisher previously relied on the Media Library Form API Element, which caused compatibility issues for Drupal 10 versions below 10.3.

- Removed the hard dependency on the media_library_form_element module
- Added dependency for the core media module as it is required.

<img width="1064" height="249" alt="Screenshot 2025-12-03 at 12 03 34 PM" src="https://github.com/user-attachments/assets/c2d34f52-d3f6-4617-af32-b050e0452347" />

 **Smart Component Improvements**

The icon field in PantheonSmartComponentForm is now optional.

The field appears only when the Media Library form element type is available.

Smart Components continue to function normally even when no icon is provided.

