### PR TITLE
[SITE-5353] Add css for pantheon content publisher preview

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,8 @@
     },
     "config": {
         "allow-plugins": {
+            "composer/installers": true,
+            "drupal/core-composer-scaffold": true,
             "dealerdirect/phpcodesniffer-composer-installer": true
         }
     }

--- a/css/preview.css
+++ b/css/preview.css
@@ -6,7 +6,7 @@
 
 #pantheon-content-publisher-preview {
   /* ==========================================================================
-     1. Global base elements
+     Global base elements
      ========================================================================== */
 
   iframe {
@@ -24,7 +24,7 @@
   }
 
   /* ==========================================================================
-     2. Responsive video wrapper patterns
+     Responsive video wrapper patterns
      ========================================================================== */
 
   .responsive-video,
@@ -35,18 +35,20 @@
     height: 0;
     overflow: hidden;
     max-width: 100%;
+  }
 
-    iframe {
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-    }
+  .responsive-video iframe,
+  .media--type-remote-video iframe,
+  .embedded-video iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
   }
 
   /* ==========================================================================
-     3. Generic wrapper classes
+     Generic wrapper classes
      ========================================================================== */
 
   .media-wrapper,
@@ -57,7 +59,7 @@
   }
 
   /* ==========================================================================
-     4. Specific targeting
+     Specific targeting
      ========================================================================== */
 
   /* Common video service embeds */
@@ -69,30 +71,23 @@
     height: 100%;
   }
 
-  /* Embedded entity support */
-  .embedded-entity {
+  /* video_embed_field module patterns */
+  .video-embed-field-responsive-video {
+    position: relative;
+    padding-bottom: 56.25%; /* 16:9 aspect ratio */
+    height: 0;
+    overflow: hidden;
     max-width: 100%;
-
-    iframe {
-      max-width: 100%;
-    }
   }
 
-  /* video_embed_field module patterns */
- .video-embed-field-responsive-video {
-  position: relative;
-  padding-bottom: 56.25%; /* 16:9 aspect ratio */
-  height: 0;
-  overflow: hidden;
-  max-width: 100%;
- }
-
- .video-embed-field-responsive-video iframe {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
- }
-
+  .video-embed-field-responsive-video iframe {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+  }
 }

--- a/css/preview.css
+++ b/css/preview.css
@@ -77,4 +77,22 @@
       max-width: 100%;
     }
   }
+
+  /* video_embed_field module patterns */
+ .video-embed-field-responsive-video {
+  position: relative;
+  padding-bottom: 56.25%; /* 16:9 aspect ratio */
+  height: 0;
+  overflow: hidden;
+  max-width: 100%;
+ }
+
+ .video-embed-field-responsive-video iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+ }
+
 }

--- a/css/preview.css
+++ b/css/preview.css
@@ -1,0 +1,80 @@
+/**
+ * @file
+ * Styling for Content Publisher preview.
+ *
+ */
+
+#pantheon-content-publisher-preview {
+  /* ==========================================================================
+     1. Global base elements
+     ========================================================================== */
+
+  iframe {
+    max-width: 100%;
+  }
+
+  video {
+    max-width: 100%;
+    height: auto;
+  }
+
+  img {
+    max-width: 100%;
+    height: auto;
+  }
+
+  /* ==========================================================================
+     2. Responsive video wrapper patterns
+     ========================================================================== */
+
+  .responsive-video,
+  .media--type-remote-video,
+  .embedded-video {
+    position: relative;
+    padding-bottom: 56.25%; /* 16:9 aspect ratio */
+    height: 0;
+    overflow: hidden;
+    max-width: 100%;
+
+    iframe {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+    }
+  }
+
+  /* ==========================================================================
+     3. Generic wrapper classes
+     ========================================================================== */
+
+  .media-wrapper,
+  .video-wrapper,
+  .embed-container {
+    max-width: 100%;
+    overflow: hidden;
+  }
+
+  /* ==========================================================================
+     4. Specific targeting
+     ========================================================================== */
+
+  /* Common video service embeds */
+  iframe[src*="youtube.com"],
+  iframe[src*="youtu.be"],
+  iframe[src*="vimeo.com"],
+  iframe[src*="player.vimeo.com"] {
+    max-width: 100%;
+    height: 100%;
+  }
+
+  /* Embedded entity support */
+  .embedded-entity {
+    max-width: 100%;
+
+    iframe {
+      max-width: 100%;
+    }
+  }
+}

--- a/pantheon_content_publisher.libraries.yml
+++ b/pantheon_content_publisher.libraries.yml
@@ -1,4 +1,7 @@
 preview:
+  css:
+    component:
+      css/preview.css: {}
   js:
     js/preview.js: { preprocess: false }
   dependencies:


### PR DESCRIPTION
Issue
Drupal library attachments are not appearing in the content Publisher preview, and  as a result smart components are not responsive  and overflow the preview area.. 

**Solution**
As a workaround, CSS is being added to make the iframe components responsive and to prevent the overflow of the iframe.

<img width="1725" height="991" alt="Screenshot 2025-12-17 at 6 21 57 PM" src="https://github.com/user-attachments/assets/cef79a88-51a3-4a99-91e5-f7290f6ed420" />


<img width="1728" height="1022" alt="Screenshot 2025-12-17 at 11 59 57 AM" src="https://github.com/user-attachments/assets/a8c20df1-be4e-43b4-8872-998726d0f7ae" />