### PR TITLE
[SITE-5231] #2  Add support for DRAFT publishing level in approval workflow

### DIFF
--- a/js/source/preview.js
+++ b/js/source/preview.js
@@ -8,6 +8,8 @@ const pantheonClient = new PantheonClient({
     token: 'pcc_grant ' + params.get('pccGrant')
 });
 
+// This library only loads for REALTIME publishing level.
+// DRAFT uses server-side rendering and doesn't load this library.
 pantheonClient.apolloClient.subscribe({
     query: ARTICLE_UPDATE_SUBSCRIPTION,
     variables: {

--- a/src/Controller/PantheonContentPublisherViewController.php
+++ b/src/Controller/PantheonContentPublisherViewController.php
@@ -19,8 +19,9 @@ class PantheonContentPublisherViewController extends EntityViewController {
 
   public function pantheonView(Request $request, $pantheon_id): array {
     $query = $request->query;
-    $publishingLevel = $query->get('publishingLevel');
-    $versionId = $query->get('versionId');
+    $publishingLevel = in_array($query->get('publishingLevel'), ['PRODUCTION', 'REALTIME', 'DRAFT'], TRUE)
+      ? $query->get('publishingLevel')
+      : NULL;
     $is_preview = in_array($publishingLevel, ['REALTIME', 'DRAFT'], TRUE);
     $is_realtime = $publishingLevel === 'REALTIME';
     $collection = $query->get('siteId') ?: array_key_first(PantheonDocumentCollection::loadMultiple());

--- a/src/Controller/PantheonContentPublisherViewController.php
+++ b/src/Controller/PantheonContentPublisherViewController.php
@@ -19,7 +19,10 @@ class PantheonContentPublisherViewController extends EntityViewController {
 
   public function pantheonView(Request $request, $pantheon_id): array {
     $query = $request->query;
-    $is_preview = $query->get('publishingLevel') === 'REALTIME';
+    $publishingLevel = $query->get('publishingLevel');
+    $versionId = $query->get('versionId');
+    $is_preview = in_array($publishingLevel, ['REALTIME', 'DRAFT'], TRUE);
+    $is_realtime = $publishingLevel === 'REALTIME';
     $collection = $query->get('siteId') ?: array_key_first(PantheonDocumentCollection::loadMultiple());
     try {
       $document = PantheonDocument::load(PantheonDocumentStorage::getEntityId($collection, $pantheon_id));
@@ -32,18 +35,25 @@ class PantheonContentPublisherViewController extends EntityViewController {
         throw $e;
       }
     }
-    if ($is_preview) {
+    if ($is_realtime) {
+      // Only REALTIME needs empty preview div for client-side rendering.
+      // DRAFT uses server-side rendering (document loaded via PantheonDocumentStorage).
       // PantheonTagsFormatter turns this into
       // <div id="pantheon-content-publisher-preview"></div>
       $document->get('content')->value = '{"attrs":{"id":"pantheon-content-publisher-preview"}}';
     }
     $page = $this->view($document);
     if ($is_preview) {
-      $page['#attached']['library'][] = 'pantheon_content_publisher/preview';
-      $page['#attached']['drupalSettings']['pantheon_content_publisher']['site_id'] = $collection;
+      // Remove X-Frame-Options for both REALTIME and DRAFT (iframe support).
       $page['#attached']['http_header'][] = [PantheonContentPublisherXFrameSubscriber::HEADER_NAME, ''];
     }
+    if ($is_realtime) {
+      // Only REALTIME needs preview JavaScript library for live updates.
+      $page['#attached']['library'][] = 'pantheon_content_publisher/preview';
+      $page['#attached']['drupalSettings']['pantheon_content_publisher']['site_id'] = $collection;
+    }
     $page['#cache']['contexts'][] = 'url.query_args:publishingLevel';
+    $page['#cache']['contexts'][] = 'url.query_args:versionId';
     return $page;
   }
 

--- a/src/Controller/PantheonContentPublisherViewController.php
+++ b/src/Controller/PantheonContentPublisherViewController.php
@@ -37,14 +37,14 @@ class PantheonContentPublisherViewController extends EntityViewController {
     }
     if ($is_realtime) {
       // Only REALTIME needs empty preview div for client-side rendering.
-      // DRAFT uses server-side rendering (document loaded via PantheonDocumentStorage).
+      // DRAFT and PRODUCTION use server-side rendering (document loaded via PantheonDocumentStorage).
       // PantheonTagsFormatter turns this into
       // <div id="pantheon-content-publisher-preview"></div>
       $document->get('content')->value = '{"attrs":{"id":"pantheon-content-publisher-preview"}}';
     }
     $page = $this->view($document);
-    if ($is_preview) {
-      // Remove X-Frame-Options for both REALTIME and DRAFT (iframe support).
+    if ($publishingLevel) {
+      // Remove X-Frame-Options for all publishing levels (PRODUCTION, REALTIME, DRAFT) to allow iframe embedding in Content Publisher.
       $page['#attached']['http_header'][] = [PantheonContentPublisherXFrameSubscriber::HEADER_NAME, ''];
     }
     if ($is_realtime) {

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\pantheon_content_publisher;
 
 use GraphQL\RequestBuilder\Argument;
+use GraphQL\RequestBuilder\EnumArgument;
 use GraphQL\RequestBuilder\Interfaces\TypeInterface;
 use GraphQL\RequestBuilder\RootType;
 use GraphQL\RequestBuilder\Type;
@@ -44,7 +45,7 @@ class GraphQL {
       'metadata',
     ]);
     if ($publishingLevel) {
-      $query->addArgument(new Argument('publishingLevel', $publishingLevel));
+      $query->addArgument(new EnumArgument('publishingLevel', $publishingLevel));
     }
     if ($versionId) {
       $query->addArgument(new Argument('versionId', $versionId));

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -23,10 +23,17 @@ class GraphQL {
   /**
    * Get an article.
    *
+   * @param string $id
+   *   The article ID.
+   * @param string|null $publishingLevel
+   *   The publishing level (PRODUCTION, REALTIME, or DRAFT).
+   * @param string|null $versionId
+   *   The specific version ID to retrieve (for DRAFT publishing level).
+   *
    * @return array
    *   title, content and metadata of the article.
    */
-  public function getArticle(string $id): array {
+  public function getArticle(string $id, ?string $publishingLevel = NULL, ?string $versionId = NULL): array {
     $query = (new RootType('article'))->addArgument(new Argument('id', $id))->addSubTypes([
       'title',
       'content',
@@ -36,6 +43,12 @@ class GraphQL {
       'publishStatus',
       'metadata',
     ]);
+    if ($publishingLevel) {
+      $query->addArgument(new Argument('publishingLevel', $publishingLevel));
+    }
+    if ($versionId) {
+      $query->addArgument(new Argument('versionId', $versionId));
+    }
     return $this->request($query);
   }
 

--- a/src/PantheonDocumentStorage.php
+++ b/src/PantheonDocumentStorage.php
@@ -16,6 +16,7 @@ use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\pantheon_content_publisher\Entity\PantheonDocument;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Provides a list controller for the pantheon content publisher entity type.
@@ -32,6 +33,7 @@ class PantheonDocumentStorage extends ContentEntityStorageBase implements Panthe
     EntityTypeBundleInfoInterface $entity_type_bundle_info,
     protected EntityStorageInterface $collectionStorage,
     protected PantheonContentPublisherConverter $pantheonContentPublisherConverter,
+    protected RequestStack $requestStack,
   ) {
     parent::__construct($entity_type, $entity_field_manager, $cache, $memory_cache, $entity_type_bundle_info);
   }
@@ -44,19 +46,23 @@ class PantheonDocumentStorage extends ContentEntityStorageBase implements Panthe
       $container->get('entity.memory_cache'),
       $container->get('entity_type.bundle.info'),
       $container->get('entity_type.manager')->getStorage('pantheon_document_collection'),
-      $container->get('pantheon_content_publisher.converter')
+      $container->get('pantheon_content_publisher.converter'),
+      $container->get('request_stack')
     );
   }
 
   protected function doLoadMultiple(?array $ids = NULL) {
     $entities = [];
+    $request = $this->requestStack->getCurrentRequest();
+    $publishingLevel = $request?->query->get('publishingLevel');
+    $versionId = $request?->query->get('versionId');
     foreach ($ids as $id) {
       [$collection_name, $pantheon_id] = explode(self::SEPARATOR, $id, 2);
       if (!$collection = $this->collectionStorage->load($collection_name)) {
         continue;
       }
       try {
-        $pantheon_data = $collection->getGraphQL()->getArticle($pantheon_id);
+        $pantheon_data = $collection->getGraphQL()->getArticle($pantheon_id, $publishingLevel, $versionId);
       }
       catch (GraphQLException $e) {
         continue;

--- a/tests/src/Kernel/PantheonContentDocumentTestInterface.php
+++ b/tests/src/Kernel/PantheonContentDocumentTestInterface.php
@@ -23,7 +23,7 @@ interface PantheonContentDocumentTestInterface {
    */
   const QUERIES = [
     'metadata' => '{site(id:"%s"){metadataFields}}',
-    'getArticle' => '{article(id:"%s"){title,content,slug,metadata}}',
+    'getArticle' => '{article(id:"%s"){title,content,slug,createdAt,publishedDate,publishStatus,metadata}}',
     'getArticles' => '{articlesv3{articles{id,title,metadata}}}',
     'getArticleIds' => '{articlesv3(pageSize:100){articles{id},pageInfo{nextCursor}}}',
     'getArticleIdsButJustOne' => '{articlesv3(pageSize:1){articles{id},pageInfo{nextCursor}}}',

--- a/tests/src/Kernel/PantheonDocumentTest.php
+++ b/tests/src/Kernel/PantheonDocumentTest.php
@@ -158,22 +158,40 @@ class PantheonDocumentTest extends KernelTestBase implements PantheonContentDocu
   }
 
   public function testDraftPreview() {
+    // Reset entity cache to force a fresh GraphQL request.
+    $this->container->get('entity_type.manager')->getStorage('pantheon_document')->resetCache();
+    // Register a mock response for the DRAFT GraphQL query with distinct
+    // content so we can verify the DRAFT query is actually being sent.
+    $draftArticle = $this->getArticle();
+    $draftArticle['content'] = 'draft content';
+    $draftQuery = sprintf('{article(id:"%s",publishingLevel:DRAFT){title,content,slug,createdAt,publishedDate,publishStatus,metadata}}', static::ARTICLE_ID);
+    $this->storage[$draftQuery] = json_encode(['data' => ['article' => $draftArticle]]);
+
     $response = $this->handle(sprintf('/api/pantheoncloud/document/%s?publishingLevel=DRAFT', static::ARTICLE_ID));
     $this->assertFalse($response->headers->has('X-Frame-Options'));
     $this->assertFalse($response->headers->has(PantheonContentPublisherXFrameSubscriber::HEADER_NAME));
-    // DRAFT uses server-side rendering, so content should be present.
-    $this->assertStringContainsString('test content', $response->getContent());
+    // DRAFT uses server-side rendering with the draft-specific content.
+    $this->assertStringContainsString('draft content', $response->getContent());
     // DRAFT should NOT load preview.js library.
     $this->assertStringNotContainsString('preview.js', $response->getContent());
   }
 
   public function testDraftPreviewWithVersionId() {
+    // Reset entity cache to force a fresh GraphQL request.
+    $this->container->get('entity_type.manager')->getStorage('pantheon_document')->resetCache();
+    // Register a mock response for the DRAFT+versionId GraphQL query with
+    // distinct content to verify both parameters reach the API.
     $versionId = 'test-version-id-123';
+    $draftArticle = $this->getArticle();
+    $draftArticle['content'] = 'draft version content';
+    $draftQuery = sprintf('{article(id:"%s",publishingLevel:DRAFT,versionId:"%s"){title,content,slug,createdAt,publishedDate,publishStatus,metadata}}', static::ARTICLE_ID, $versionId);
+    $this->storage[$draftQuery] = json_encode(['data' => ['article' => $draftArticle]]);
+
     $response = $this->handle(sprintf('/api/pantheoncloud/document/%s?publishingLevel=DRAFT&versionId=%s', static::ARTICLE_ID, $versionId));
     $this->assertFalse($response->headers->has('X-Frame-Options'));
     $this->assertFalse($response->headers->has(PantheonContentPublisherXFrameSubscriber::HEADER_NAME));
-    // DRAFT uses server-side rendering, so content should be present.
-    $this->assertStringContainsString('test content', $response->getContent());
+    // DRAFT uses server-side rendering with the version-specific content.
+    $this->assertStringContainsString('draft version content', $response->getContent());
     // DRAFT should NOT load preview.js library.
     $this->assertStringNotContainsString('preview.js', $response->getContent());
   }

--- a/tests/src/Kernel/PantheonDocumentTest.php
+++ b/tests/src/Kernel/PantheonDocumentTest.php
@@ -152,8 +152,30 @@ class PantheonDocumentTest extends KernelTestBase implements PantheonContentDocu
     $response = $this->handle(sprintf('/api/pantheoncloud/document/%s?publishingLevel=REALTIME', static::ARTICLE_ID));
     $this->assertFalse($response->headers->has('X-Frame-Options'));
     $this->assertFalse($response->headers->has(PantheonContentPublisherXFrameSubscriber::HEADER_NAME));
+    // REALTIME creates empty preview div for client-side rendering.
     $this->assertStringContainsString('<div id="pantheon-content-publisher-preview"></div>', $response->getContent());
     // @TODO assert preview.js is loaded.
+  }
+
+  public function testDraftPreview() {
+    $response = $this->handle(sprintf('/api/pantheoncloud/document/%s?publishingLevel=DRAFT', static::ARTICLE_ID));
+    $this->assertFalse($response->headers->has('X-Frame-Options'));
+    $this->assertFalse($response->headers->has(PantheonContentPublisherXFrameSubscriber::HEADER_NAME));
+    // DRAFT uses server-side rendering, so content should be present.
+    $this->assertStringContainsString('test content', $response->getContent());
+    // DRAFT should NOT load preview.js library.
+    $this->assertStringNotContainsString('preview.js', $response->getContent());
+  }
+
+  public function testDraftPreviewWithVersionId() {
+    $versionId = 'test-version-id-123';
+    $response = $this->handle(sprintf('/api/pantheoncloud/document/%s?publishingLevel=DRAFT&versionId=%s', static::ARTICLE_ID, $versionId));
+    $this->assertFalse($response->headers->has('X-Frame-Options'));
+    $this->assertFalse($response->headers->has(PantheonContentPublisherXFrameSubscriber::HEADER_NAME));
+    // DRAFT uses server-side rendering, so content should be present.
+    $this->assertStringContainsString('test content', $response->getContent());
+    // DRAFT should NOT load preview.js library.
+    $this->assertStringNotContainsString('preview.js', $response->getContent());
   }
 
 }

--- a/tests/src/Kernel/PantheonDocumentTestTrait.php
+++ b/tests/src/Kernel/PantheonDocumentTestTrait.php
@@ -209,6 +209,9 @@ trait PantheonDocumentTestTrait {
       'content' => $this->articleContent,
       'title' => 'test title',
       'slug' => 'test-slug',
+      'createdAt' => ['msSinceEpoch' => 1741385249172],
+      'publishedDate' => ['msSinceEpoch' => 1741385249172],
+      'publishStatus' => 'PUBLISHED',
     ];
   }
 


### PR DESCRIPTION
Implements DRAFT publishing level support for the approval workflow. Ensures all three publishing levels (PRODUCTION, REALTIME  and  DRAFT) work correctly with proper rendering strategies and iframe embedding.

- Added publishingLevel and versionId parameters to support DRAFT publishing level
- Removed the X-Frame-Options header for all publishing levels to allow iframe embedding in preview
- Added test coverage to verify correct rendering behavior for DRAFT and REALTIME

### **Draft preview before requesting approval**

<img width="1728" height="902" alt="Screenshot 2026-02-04 at 10 56 17 AM" src="https://github.com/user-attachments/assets/ba444c0a-05bc-491d-9f90-608bf49b24e2" />

### **Draft and Production Preview for Approval**

<img width="1707" height="1018" alt="Screenshot 2026-02-04 at 10 57 18 AM" src="https://github.com/user-attachments/assets/b4be6fd4-f72b-4b51-8ff3-aa669f3b2db3" />

### **Content Published after approval**

<img width="1638" height="721" alt="Screenshot 2026-02-04 at 10 57 54 AM" src="https://github.com/user-attachments/assets/1976ec55-1122-4839-9d0b-71be8d6e62d6" />
