### PR TITLE
Set VCS repository as non-canonical to fix composer resolution

### DIFF
--- a/.github/scripts/create-multidev.sh
+++ b/.github/scripts/create-multidev.sh
@@ -33,7 +33,7 @@ echo "Checking out branch $MULTIDEV..."
 git checkout "$MULTIDEV"
 
 # Add pantheon_content_publisher module via composer
-composer config repositories.pantheon_content_publisher vcs git@github.com:pantheon-systems/pantheon-content-publisher-drupal.git
+composer config repositories.pantheon_content_publisher '{"type": "vcs", "url": "git@github.com:pantheon-systems/pantheon-content-publisher-drupal.git", "canonical": false}'
 composer require drupal/pantheon_content_publisher:"${GIT_REF}"
 
 # Show where the module was installed for diagnostics.


### PR DESCRIPTION
## Problem

The `create-multidev.sh` script registers the GitHub VCS repository for `pantheon_content_publisher` as **canonical** by default. This causes Composer to attempt resolving *all* packages from the GitHub VCS repo first, leading to dependency resolution failures for packages that don't exist there.

Unlike other Pantheon modules that maintain packages on both [Packagist](https://packagist.org/packages/pantheon-systems/) and `packages.drupal.org/8`, this module is only published on Drupal.org — which is the recommended practice going forward. As a result, the VCS repository must be explicitly marked as non-canonical to avoid interfering with resolution of other dependencies.

## Fix

Configures the VCS repository with `"canonical": false` so that Composer only uses it for `pantheon_content_publisher` and falls back to `packages.drupal.org`/Packagist for all other dependencies.
