### PR TITLE
[SITE-5576] Check module existence to avoid stale cache of media_library_form_element

### DIFF
--- a/src/Form/PantheonSmartComponentForm.php
+++ b/src/Form/PantheonSmartComponentForm.php
@@ -6,7 +6,7 @@ namespace Drupal\pantheon_content_publisher\Form;
 
 use Drupal\Core\Entity\EntityForm;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Render\ElementInfoManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Url;
 use Drupal\pantheon_content_publisher\Entity\PantheonSmartComponent;
 
@@ -40,9 +40,8 @@ class PantheonSmartComponentForm extends EntityForm {
       '#disabled' => !$this->entity->isNew(),
     ];
 
-    // Removed hard dependency on media_library_form_element contrib module.
-    // Only add icon field if media_library form element is available.
-    if (\Drupal::service(ElementInfoManagerInterface::class)->getDefinition('media_library', FALSE)) {
+    // Only add icon field if media_library_form_element contrib module is installed.
+    if (\Drupal::service(ModuleHandlerInterface::class)->moduleExists('media_library_form_element')) {
       $form['icon_media'] = [
         '#type' => 'media_library',
         '#title' => $this->t('Icon'),


### PR DESCRIPTION
**Summary**

The `media_library_form_element` module was removed as a dependency for the Content Publisher module from version 1.0.4. The smart component icon field was modified to only show if the `media_library` plugin definition exists. However, for users upgrading from a previous version, `ElementInfoManagerInterface::getDefinition('media_library')` can return stale cached plugin definitions, and if the backing class doesn't exist, it can throw a `PluginException`.


- Core's Media Library (`media_library` core module) provides a `media_library` render element — but it's a widget for entity reference fields, not a standalone form element you can drop into custom forms easily.

- `media_library_form_element` is a contrib module that wraps the media library into a reusable form element for custom forms (like the Smart Component form).

**Issue**

The previous check was too broad — it would pass if core's Media Library module was enabled, even though the code actually depends on the contrib module's form element behavior.

**Fix**

This PR replaces the plugin definition check with `ModuleHandlerInterface::moduleExists('media_library_form_element')`, which is explicit and correct: it only adds the icon field when the specific contrib module that provides the expected form element API is installed, without depending on cached plugin definitions.

