### PR TITLE
[SITE-5203] Add PHP 8.5 to CI and update README

### DIFF
--- a/.github/scripts/cleanup-multidevs.sh
+++ b/.github/scripts/cleanup-multidevs.sh
@@ -1,26 +1,58 @@
 #!/bin/bash
 #
 # @file Cleanup stale CI multidev environments.
-# Deletes all multidevs matching a given prefix, except the current one.
+#
+# Two-pass cleanup:
+#   1. Prefix match: delete multidevs from same matrix combo (prior runs)
+#   2. Age-based sweep: delete any CI-pattern multidev older than 72h
 #
 # Requires: TERMINUS_SITE environment variable.
 # Arguments:
-#   $1 - Prefix to match (e.g., "ci-d10-")
+#   $1 - Prefix to match (e.g., "d10p82-")
 #   $2 - Current environment name to keep (optional)
 
 set -eo pipefail
 
 PREFIX="$1"
 CURRENT_ENV="${2:-}"
+MAX_AGE_HOURS=72
+
+# Matches CI-generated multidev names like d10p82-25, d11p83-31
+# (no solr dimension, unlike search_api_pantheon)
+CI_PATTERN='^d[0-9]+p[0-9]+-[0-9]+'
 
 if [[ -z "$TERMINUS_SITE" || -z "$PREFIX" ]]; then
   echo "::error::TERMINUS_SITE and PREFIX (arg 1) must be set."
   exit 1
 fi
 
-for env in $(terminus multidev:list "$TERMINUS_SITE" --format=list 2>/dev/null); do
-  if [[ "$env" == ${PREFIX}* && "$env" != "$CURRENT_ENV" ]]; then
-    echo "Deleting stale multidev: $env"
+NOW=$(date +%s)
+CUTOFF=$((NOW - MAX_AGE_HOURS * 3600))
+
+# JSON output includes creation timestamps needed for age-based cleanup
+MULTIDEVS=$(terminus multidev:list "$TERMINUS_SITE" --format=json 2>/dev/null || echo "{}")
+
+for env in $(echo "$MULTIDEVS" | jq -r 'keys[]' 2>/dev/null); do
+  # Skip the current run's multidev.
+  # On success, the "Delete current multidev" CI step already removed it.
+  # On failure, we want it to persist for investigation.
+  if [[ "$env" == "$CURRENT_ENV" ]]; then
+    continue
+  fi
+
+  # Pass 1: prefix match (same matrix combo from prior runs)
+  if [[ "$env" == ${PREFIX}* ]]; then
+    echo "Deleting stale multidev (prefix match): $env"
     terminus multidev:delete "$TERMINUS_SITE.$env" --delete-branch --yes || true
+    continue
+  fi
+
+  # Pass 2: age-based sweep (orphans from retired matrix combos)
+  if [[ "$env" =~ $CI_PATTERN ]]; then
+    CREATED=$(echo "$MULTIDEVS" | jq -r --arg e "$env" '.[$e].created // 0' 2>/dev/null)
+    if [[ "$CREATED" -gt 0 && "$CREATED" -lt "$CUTOFF" ]]; then
+      echo "Deleting old CI multidev (age > ${MAX_AGE_HOURS}h): $env"
+      terminus multidev:delete "$TERMINUS_SITE.$env" --delete-branch --yes || true
+    fi
   fi
 done

--- a/.github/scripts/create-multidev.sh
+++ b/.github/scripts/create-multidev.sh
@@ -5,6 +5,7 @@ MULTIDEV_NAME="$1"
 TERMINUS_SITE="$2"
 GITHUB_ENV_FILE="${3:-${GITHUB_ENV:-}}"
 GIT_REF="${4:-dev-1.0.x}"
+PHP_VERSION="${5:-}"
 
 # Limit multidev name to 11 characters
 MULTIDEV="${MULTIDEV_NAME:0:11}"
@@ -53,9 +54,24 @@ if [ -n "${MODULE_INSTALL_PATH:-}" ]; then
 fi
 rm -rf vendor/*/.git/
 
+# Set PHP version in pantheon.yml if specified.
+if [ -n "$PHP_VERSION" ]; then
+  echo "Setting PHP version to ${PHP_VERSION}..."
+  if [ -f pantheon.yml ]; then
+    if grep -q "php_version:" pantheon.yml; then
+      sed -i "s/php_version:.*/php_version: ${PHP_VERSION}/" pantheon.yml
+    else
+      echo "php_version: ${PHP_VERSION}" >> pantheon.yml
+    fi
+  else
+    echo "api_version: 1" > pantheon.yml
+    echo "php_version: ${PHP_VERSION}" >> pantheon.yml
+  fi
+fi
+
 # Commit and push changes
 git add .
-git commit -m 'Add pantheon_content_publisher module'
+git commit -m "Add pantheon_content_publisher module (PHP ${PHP_VERSION:-default})"
 git push --set-upstream origin "$MULTIDEV"
 
 cd ..

--- a/.github/scripts/create-multidev.sh
+++ b/.github/scripts/create-multidev.sh
@@ -10,7 +10,7 @@ PHP_VERSION="${5:-}"
 # Limit multidev name to 11 characters
 MULTIDEV="${MULTIDEV_NAME:0:11}"
 
-# Check if  multidev with the same name already exists, if so delete it
+# Check if multidev with the same name already exists, if so delete it
 if terminus multidev:list "$TERMINUS_SITE" --format=list | grep -q "^$MULTIDEV$"; then
   terminus multidev:delete "$TERMINUS_SITE.$MULTIDEV" --delete-branch --yes
 fi
@@ -33,7 +33,8 @@ cd pantheon-site
 echo "Checking out branch $MULTIDEV..."
 git checkout "$MULTIDEV"
 
-# Add pantheon_content_publisher module via composer
+# Add pantheon_content_publisher module via composer.
+# VCS repo allows installing branch builds (not just tagged releases).
 composer config repositories.pantheon_content_publisher '{"type": "vcs", "url": "git@github.com:pantheon-systems/pantheon-content-publisher-drupal.git", "canonical": false}'
 composer require drupal/pantheon_content_publisher:"${GIT_REF}"
 
@@ -42,6 +43,7 @@ echo "Module installed at:"
 find . -path '*/pantheon_content_publisher/pantheon_content_publisher.info.yml' -not -path './vendor/*' | head -1
 
 # Remove git directories from submodules.
+# Pantheon's git-based deployment rejects pushes with nested .git dirs.
 # Detect the module path dynamically (nested docroot vs flat).
 if [ -d web/modules/contrib/pantheon_content_publisher/.git ]; then
   MODULE_INSTALL_PATH="web/modules/contrib/pantheon_content_publisher"
@@ -55,6 +57,7 @@ fi
 rm -rf vendor/*/.git/
 
 # Set PHP version in pantheon.yml if specified.
+# Without this, tests run under the base site's default PHP, not the matrix PHP.
 if [ -n "$PHP_VERSION" ]; then
   echo "Setting PHP version to ${PHP_VERSION}..."
   if [ -f pantheon.yml ]; then

--- a/.github/scripts/run-tests.sh
+++ b/.github/scripts/run-tests.sh
@@ -2,6 +2,8 @@
 #
 # @file Remote Test Orchestrator for Pantheon
 # Executes Unit and Kernel tests on a Multidev environment.
+# Uses sentinel strings (SENTINEL_SUCCESS/SENTINEL_ERROR) to detect pass/fail
+# since exit codes are unreliable through the terminus remote execution chain.
 #
 # Requires: TERMINUS_SITE, MULTIDEV_ENV environment variables.
 
@@ -17,6 +19,7 @@ SITE_ENV="${TERMINUS_SITE}.${MULTIDEV_ENV}"
 BASE_URL="https://${MULTIDEV_ENV}-${TERMINUS_SITE}.pantheonsite.io"
 
 # ── Ensure writable filesystem ───────────────────────────────────────
+# SFTP mode needed for PHPUnit to write temp files during test execution.
 terminus connection:set "$SITE_ENV" sftp -y 2>/dev/null || true
 
 # ── PHP payload template ─────────────────────────────────────────────
@@ -71,6 +74,7 @@ run_tests() {
   # 2>/dev/null suppresses the Terminus "[notice] Command:" line that
   # otherwise dumps the full PHP payload (including DB credentials)
   # into CI logs. Test output (stdout from passthru) is preserved.
+  # sed redacts any DB connection strings that leak through.
   local output
   output=$(terminus remote:drush "$SITE_ENV" -- ev "$php_code" 2>/dev/null \
     | sed -E 's|mysql://[^@]*@|mysql://REDACTED@|g')

--- a/.github/scripts/run-tests.sh
+++ b/.github/scripts/run-tests.sh
@@ -53,6 +53,7 @@ $cmd = sprintf(
 );
 
 passthru($cmd, $exit_status);
+
 if ($exit_status === 0) echo 'SENTINEL_SUCCESS';
 PHPEOF
 

--- a/.github/scripts/run-tests.sh
+++ b/.github/scripts/run-tests.sh
@@ -53,7 +53,6 @@ $cmd = sprintf(
 );
 
 passthru($cmd, $exit_status);
-
 if ($exit_status === 0) echo 'SENTINEL_SUCCESS';
 PHPEOF
 

--- a/.github/scripts/set-multidev-and-constraint.sh
+++ b/.github/scripts/set-multidev-and-constraint.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -eo pipefail
+
+# Set multidev environment variables and composer constraint for CI.
+# Reads from job env: DRUPAL_VERSION, PHP_VERSION, GITHUB_RUN_NUMBER
+# Reads from step env: GIT_REF, GIT_REF_TYPE
+# Writes to $GITHUB_ENV: MULTIDEV_NAME, MULTIDEV_PREFIX, GIT_CONSTRAINT
+
+if [[ -z "$DRUPAL_VERSION" || -z "$PHP_VERSION" || -z "$GITHUB_RUN_NUMBER" ]]; then
+  echo "::error::DRUPAL_VERSION, PHP_VERSION, and GITHUB_RUN_NUMBER must be set."
+  exit 1
+fi
+
+# Multidev name: d{drupal}p{php}-{run} e.g. d10p82-42 (max 11 chars, truncated in create-multidev.sh)
+PHP_SHORT=$(echo "$PHP_VERSION" | tr -d '.')
+echo "MULTIDEV_NAME=d${DRUPAL_VERSION}p${PHP_SHORT}-${GITHUB_RUN_NUMBER}" >> "$GITHUB_ENV"
+
+# Prefix used by cleanup script to find stale multidevs from prior runs
+echo "MULTIDEV_PREFIX=d${DRUPAL_VERSION}p${PHP_SHORT}-" >> "$GITHUB_ENV"
+
+# Convert git ref to a composer version constraint:
+#   Tags (e.g. 1.0.0-beta1)             -> use as-is: 1.0.0-beta1
+#   Version-like branches (e.g. 1.0.x)  -> branch-dev format: 1.0.x-dev
+#   Other branches (e.g. my-feature)     -> dev-branch format: dev-my-feature
+REF="${GIT_REF:?GIT_REF must be set}"
+if [ "${GIT_REF_TYPE}" = "tag" ]; then
+  echo "GIT_CONSTRAINT=${REF}" >> "$GITHUB_ENV"
+elif echo "$REF" | grep -qE '^v?[0-9]+(\.[0-9x]+)*$'; then
+  echo "GIT_CONSTRAINT=${REF}-dev" >> "$GITHUB_ENV"
+else
+  echo "GIT_CONSTRAINT=dev-${REF}" >> "$GITHUB_ENV"
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
       PHP_VERSION: ${{ matrix.php-version }}
       TERMINUS_SITE: ${{ matrix.drupal-version == 10 && vars.PANTHEON_SITE_D10 || vars.PANTHEON_SITE_D11 }}
       TERMINUS_TOKEN: ${{ secrets.TERMINUS_TOKEN }}
-      TERMINUS_VERSION: ${{ matrix.php-version >= '8.2' && '4.1.4' || '3.5.1' }}
+      TERMINUS_VERSION: '4.1.4'
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -74,7 +74,7 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-latest
     name: Multidev test (Drupal ${{ matrix.drupal-version }}, PHP ${{ matrix.php-version }})
-    # needs: [linting, phpcompatibility]  # Temporarily disabled for testing
+    needs: [linting, phpcompatibility]
     env:
       TZ: "/usr/share/zoneinfo/America/Los_Angeles"
       TERM: dumb
@@ -127,14 +127,6 @@ jobs:
         run: |
           echo "Runner PHP: $(php -v | head -1)"
           echo "Multidev PHP: $(terminus drush $TERMINUS_SITE.$MULTIDEV_ENV -- ev "echo 'PHP ' . PHP_VERSION;")"
-
-      - name: Check for PHP deprecation warnings
-        run: |
-          echo "=== Testing if deprecation warnings are visible ==="
-          echo "--- Direct eval (stderr visible) ---"
-          terminus remote:drush $TERMINUS_SITE.$MULTIDEV_ENV -- ev "echo (integer) 1;" 2>&1 || true
-          echo "--- Error reporting level ---"
-          terminus remote:drush $TERMINUS_SITE.$MULTIDEV_ENV -- ev "echo 'error_reporting: ' . error_reporting() . PHP_EOL . 'display_errors: ' . ini_get('display_errors');" 2>&1 || true
 
       - name: Clear cache
         run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [8.2, 8.3, 8.4]
+        php-version: [8.2, 8.3, 8.5]
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -63,30 +63,42 @@ jobs:
     strategy:
       matrix:
         drupal-version: [10, 11]
+        php-version: ["8.2", "8.3", "8.5"]
+        exclude:
+          - drupal-version: 11
+            php-version: "8.2"
+          - drupal-version: 10
+            php-version: "8.5"
       fail-fast: false
     runs-on: ubuntu-latest
-    name: Multidev test (Drupal ${{ matrix.drupal-version }})
+    name: Multidev test (Drupal ${{ matrix.drupal-version }}, PHP ${{ matrix.php-version }})
     needs: [linting, phpcompatibility]
     env:
       TZ: "/usr/share/zoneinfo/America/Los_Angeles"
       TERM: dumb
       TERMINUS_TOKEN: ${{ secrets.TERMINUS_TOKEN }}
       TERMINUS_SITE: ${{ matrix.drupal-version == 10 && vars.PANTHEON_SITE_D10 || vars.PANTHEON_SITE_D11 }}
+      TERMINUS_VERSION: ${{ matrix.php-version >= '8.4' && '4.1.4' || '3.5.1' }}
       GITHUB_RUN_NUMBER: ${{ github.run_number }}
-      MULTIDEV_NAME: ci-d${{ matrix.drupal-version }}-${{ github.run_number }}
     steps:
+      - name: Set multidev name
+        run: |
+          PHP_SHORT=$(echo "${{ matrix.php-version }}" | tr -d '.')
+          echo "MULTIDEV_NAME=d${{ matrix.drupal-version }}p${PHP_SHORT}-${{ github.run_number }}" >> $GITHUB_ENV
+          echo "MULTIDEV_PREFIX=d${{ matrix.drupal-version }}p${PHP_SHORT}-" >> $GITHUB_ENV
+
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup PHP
         uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2
         with:
-          php-version: 8.3
+          php-version: ${{ matrix.php-version }}
 
       - name: Install Terminus
         run: |
           mkdir -p $HOME/.terminus/plugins
-          curl -L https://github.com/pantheon-systems/terminus/releases/download/3.5.1/terminus.phar --output terminus
+          curl -L https://github.com/pantheon-systems/terminus/releases/download/${TERMINUS_VERSION}/terminus.phar --output terminus
           chmod +x terminus
           sudo mv terminus /usr/local/bin/terminus
           terminus --version
@@ -126,4 +138,4 @@ jobs:
 
       - name: Cleanup old CI multidevs
         if: always()
-        run: bash .github/scripts/cleanup-multidevs.sh "ci-d${{ matrix.drupal-version }}-" "${MULTIDEV_ENV:-}"
+        run: bash .github/scripts/cleanup-multidevs.sh "$MULTIDEV_PREFIX" "${MULTIDEV_ENV:-}"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,4 +1,12 @@
-name: Pull Request
+name: Content Publisher CI
+
+permissions:
+  contents: read
+
+concurrency:
+  group: 'ci-${{ github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
 on:
   pull_request:
     branches:
@@ -10,56 +18,51 @@ on:
     types: [run-tests]
   workflow_dispatch:
 
-permissions:
-  contents: read
-
-concurrency:
-  group: 'pr-${{ github.head_ref || github.ref }}'
-  cancel-in-progress: true
-
 jobs:
   linting:
-    permissions:
-      contents: read
-    name: Code linting
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [8.1, 8.5]
+        php-version: ["8.1", "8.5"]
+    name: Code linting (PHP ${{ matrix.php-version }})
     steps:
       - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: Setup PHP
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2
+        uses: shivammathur/setup-php@fcafdd6392932010c2bd5094439b8e33be2a8a09 # v2.37.0
         with:
           php-version: ${{ matrix.php-version }}
+
       - name: Cache Composer dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: vendor
           key: composer-${{ matrix.php-version }}-${{ hashFiles('composer.lock', 'composer.json') }}
           restore-keys: composer-${{ matrix.php-version }}-
+
       - name: Composer install
         run: composer install
+
       - name: Code lint
         run: composer run-script code:lint
+
       - name: Code sniff
         run: composer run-script codesniff
 
   phpcompatibility:
-    permissions:
-      contents: read
     runs-on: ubuntu-latest
     name: PHP Compatibility
     steps:
       - name: PHPCompatibility
-        uses: pantheon-systems/phpcompatibility-action@7bf1b2881e207c80ad4569874ceee225f59537d1 # v1.1.1
+        uses: pantheon-systems/phpcompatibility-action@44be5a8381691b9a209404a3f45df8254f1ce08f # v1.1.2
         with:
           test-versions: 8.2-
 
-  deploy-multidev:
-    permissions:
-      contents: read
+  deploy_multidev:
+    # Test combinations (floor + ceiling per Drupal version):
+    #   Drupal 10: PHP 8.2, 8.4
+    #   Drupal 11: PHP 8.3, 8.5
     strategy:
       matrix:
         drupal-version: [10, 11]
@@ -78,52 +81,51 @@ jobs:
     name: Multidev test (Drupal ${{ matrix.drupal-version }}, PHP ${{ matrix.php-version }})
     needs: [linting, phpcompatibility]
     env:
-      TZ: "/usr/share/zoneinfo/America/Los_Angeles"
-      TERM: dumb
-      TERMINUS_TOKEN: ${{ secrets.TERMINUS_TOKEN }}
-      TERMINUS_SITE: ${{ matrix.drupal-version == 10 && vars.PANTHEON_SITE_D10 || vars.PANTHEON_SITE_D11 }}
-      TERMINUS_VERSION: ${{ matrix.php-version >= '8.4' && '4.1.4' || '3.5.1' }}
+      DRUPAL_VERSION: ${{ matrix.drupal-version }}
+      GIT_EMAIL: ${{ secrets.GIT_EMAIL }}
       GITHUB_RUN_NUMBER: ${{ github.run_number }}
+      PANTHEON_CI_SSH_KEY: ${{ secrets.PANTHEON_CI_SSH_KEY }}
+      PHP_VERSION: ${{ matrix.php-version }}
+      TERMINUS_SITE: ${{ matrix.drupal-version == 10 && vars.PANTHEON_SITE_D10 || vars.PANTHEON_SITE_D11 }}
+      TERMINUS_TOKEN: ${{ secrets.TERMINUS_TOKEN }}
+      TERMINUS_VERSION: ${{ matrix.php-version >= '8.2' && '4.1.4' || '3.5.1' }}
     steps:
-      - name: Set multidev name
-        run: |
-          PHP_SHORT=$(echo "${{ matrix.php-version }}" | tr -d '.')
-          echo "MULTIDEV_NAME=d${{ matrix.drupal-version }}p${PHP_SHORT}-${{ github.run_number }}" >> $GITHUB_ENV
-          echo "MULTIDEV_PREFIX=d${{ matrix.drupal-version }}p${PHP_SHORT}-" >> $GITHUB_ENV
-
       - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set multidev name and composer constraint
+        run: .github/scripts/set-multidev-and-constraint.sh
+        env:
+          GIT_REF: ${{ github.head_ref || github.ref_name }}
+          GIT_REF_TYPE: ${{ github.ref_type }}
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2
+        uses: shivammathur/setup-php@fcafdd6392932010c2bd5094439b8e33be2a8a09 # v2.37.0
         with:
-          php-version: ${{ matrix.php-version }}
+          php-version: ${{ env.PHP_VERSION }}
 
       - name: Install Terminus
-        run: |
-          mkdir -p $HOME/.terminus/plugins
-          curl -L https://github.com/pantheon-systems/terminus/releases/download/${TERMINUS_VERSION}/terminus.phar --output terminus
-          chmod +x terminus
-          sudo mv terminus /usr/local/bin/terminus
-          terminus --version
+        uses: pantheon-systems/terminus-github-actions@409451ede17f75acac08f42edc823fee6c435057 # v1.2.8
+        with:
+          pantheon-machine-token: ${{ env.TERMINUS_TOKEN }}
+          terminus-version: ${{ env.TERMINUS_VERSION }}
+
+      - name: Verify Terminus auth
+        run: terminus auth:whoami
 
       - name: Setup Git
         run: |
-          git config --global user.email "${{ secrets.GIT_EMAIL }}"
+          git config --global user.email "$GIT_EMAIL"
           git config --global user.name "Github Actions"
-
-      - name: Log in to Terminus
-        run: |
-          terminus auth:login --machine-token="$TERMINUS_TOKEN"
-          terminus auth:whoami
+          git config --global --add safe.directory '*'
 
       - name: Setup SSH Keys
-        uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # v0.9.1
+        uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         with:
-          ssh-private-key: ${{ secrets.PANTHEON_CI_SSH_KEY }}
+          ssh-private-key: ${{ env.PANTHEON_CI_SSH_KEY }}
 
       - name: Create multidev environment
-        run: .github/scripts/create-multidev.sh "$MULTIDEV_NAME" "$TERMINUS_SITE" "$GITHUB_ENV" "dev-${{ github.head_ref || github.ref_name }}" "${{ matrix.php-version }}"
+        run: .github/scripts/create-multidev.sh "$MULTIDEV_NAME" "$TERMINUS_SITE" "$GITHUB_ENV" "$GIT_CONSTRAINT" "$PHP_VERSION"
 
       - name: Show PHP versions
         run: |
@@ -131,20 +133,19 @@ jobs:
           echo "Multidev PHP: $(terminus drush $TERMINUS_SITE.$MULTIDEV_ENV -- ev "echo 'PHP ' . PHP_VERSION;")"
 
       - name: Clear cache
-        run: |
-          terminus drush $TERMINUS_SITE.$MULTIDEV_ENV -- cr
+        run: terminus drush $TERMINUS_SITE.$MULTIDEV_ENV -- cr
 
       - name: Run PHPUnit tests
-        run: |
-          bash .github/scripts/run-tests.sh
+        run: bash .github/scripts/run-tests.sh
 
-      - name: Get multidev URL
-        if: always()
-        run: |
-          MULTIDEV_URL="https://$MULTIDEV_ENV-$TERMINUS_SITE.pantheonsite.io"
-          echo "Multidev URL: $MULTIDEV_URL"
-          echo "MULTIDEV_URL=$MULTIDEV_URL" >> $GITHUB_ENV
+      - name: Delete current multidev
+        if: success()
+        run: terminus multidev:delete "$TERMINUS_SITE.${MULTIDEV_ENV}" --delete-branch --yes || true
 
-      - name: Cleanup old CI multidevs
+      - name: Show multidev URL for investigation
+        if: ${{ failure() && env.MULTIDEV_ENV != '' }}
+        run: 'echo "Multidev URL: https://${MULTIDEV_ENV}-${TERMINUS_SITE}.pantheonsite.io"'
+
+      - name: Cleanup stale CI multidevs
         if: always()
         run: bash .github/scripts/cleanup-multidevs.sh "$MULTIDEV_PREFIX" "${MULTIDEV_ENV:-}"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -74,7 +74,7 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-latest
     name: Multidev test (Drupal ${{ matrix.drupal-version }}, PHP ${{ matrix.php-version }})
-    needs: [linting, phpcompatibility]
+    # needs: [linting, phpcompatibility]  # Temporarily disabled for testing
     env:
       TZ: "/usr/share/zoneinfo/America/Los_Angeles"
       TERM: dumb
@@ -127,6 +127,14 @@ jobs:
         run: |
           echo "Runner PHP: $(php -v | head -1)"
           echo "Multidev PHP: $(terminus drush $TERMINUS_SITE.$MULTIDEV_ENV -- ev "echo 'PHP ' . PHP_VERSION;")"
+
+      - name: Check for PHP deprecation warnings
+        run: |
+          echo "=== Testing if deprecation warnings are visible ==="
+          echo "--- Direct eval (stderr visible) ---"
+          terminus remote:drush $TERMINUS_SITE.$MULTIDEV_ENV -- ev "echo (integer) 1;" 2>&1 || true
+          echo "--- Error reporting level ---"
+          terminus remote:drush $TERMINUS_SITE.$MULTIDEV_ENV -- ev "echo 'error_reporting: ' . error_reporting() . PHP_EOL . 'display_errors: ' . ini_get('display_errors');" 2>&1 || true
 
       - name: Clear cache
         run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [8.2, 8.3, 8.5]
+        php-version: [8.2, 8.3, 8.4, 8.5]
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -63,10 +63,12 @@ jobs:
     strategy:
       matrix:
         drupal-version: [10, 11]
-        php-version: ["8.2", "8.3", "8.5"]
+        php-version: ["8.2", "8.3", "8.4", "8.5"]
         exclude:
           - drupal-version: 11
             php-version: "8.2"
+          - drupal-version: 10
+            php-version: "8.4"
           - drupal-version: 10
             php-version: "8.5"
       fail-fast: false
@@ -120,6 +122,11 @@ jobs:
 
       - name: Create multidev environment
         run: .github/scripts/create-multidev.sh "$MULTIDEV_NAME" "$TERMINUS_SITE" "$GITHUB_ENV" "dev-${{ github.head_ref || github.ref_name }}"
+
+      - name: Show PHP versions
+        run: |
+          echo "Runner PHP: $(php -v | head -1)"
+          echo "Multidev PHP: $(terminus drush $TERMINUS_SITE.$MULTIDEV_ENV -- ev "echo 'PHP ' . PHP_VERSION;")"
 
       - name: Clear cache
         run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [8.2, 8.3, 8.4, 8.5]
+        php-version: [8.1, 8.5]
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -65,12 +65,14 @@ jobs:
         drupal-version: [10, 11]
         php-version: ["8.2", "8.3", "8.4", "8.5"]
         exclude:
-          - drupal-version: 11
-            php-version: "8.2"
           - drupal-version: 10
-            php-version: "8.4"
+            php-version: "8.3"
           - drupal-version: 10
             php-version: "8.5"
+          - drupal-version: 11
+            php-version: "8.2"
+          - drupal-version: 11
+            php-version: "8.4"
       fail-fast: false
     runs-on: ubuntu-latest
     name: Multidev test (Drupal ${{ matrix.drupal-version }}, PHP ${{ matrix.php-version }})
@@ -121,7 +123,7 @@ jobs:
           ssh-private-key: ${{ secrets.PANTHEON_CI_SSH_KEY }}
 
       - name: Create multidev environment
-        run: .github/scripts/create-multidev.sh "$MULTIDEV_NAME" "$TERMINUS_SITE" "$GITHUB_ENV" "dev-${{ github.head_ref || github.ref_name }}"
+        run: .github/scripts/create-multidev.sh "$MULTIDEV_NAME" "$TERMINUS_SITE" "$GITHUB_ENV" "dev-${{ github.head_ref || github.ref_name }}" "${{ matrix.php-version }}"
 
       - name: Show PHP versions
         run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ["8.1", "8.5"]
+        php-version: ["8.2", "8.5"]
     name: Code linting (PHP ${{ matrix.php-version }})
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Refer the [documentation](https://pcc.pantheon.io/pantheon-content-publisher-for
 ## Requirements
 
 -  A Google Workspace Account
--  Drupal 10+ site with PHP 8.2+
+-  Drupal 10+ site with PHP 8.2+ (tested through PHP 8.5)
 -  For sites hosted on Pantheon, enable [Pantheon Search](https://docs.pantheon.io/solr) and configure the search version in your `pantheon.yml`. Follow the instructions [here](https://docs.pantheon.io/guides/solr-drupal/solr-drupal#enable-at-the-site-level)
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         }
          ],
     "require": {
+        "php": ">=8.2",
         "drupal/search_api": "^1.0",
         "drupal/imagecache_external": "^3.0",
         "dpauli/graphql-request-builder": "^1.0",

--- a/pantheon_content_publisher.module
+++ b/pantheon_content_publisher.module
@@ -7,6 +7,9 @@
 
 declare(strict_types=1);
 
+// TODO: REMOVE - testing if multidev catches PHP 8.5 deprecation.
+$_test_deprecation = (integer) 1;
+
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;

--- a/pantheon_content_publisher.module
+++ b/pantheon_content_publisher.module
@@ -7,9 +7,6 @@
 
 declare(strict_types=1);
 
-// TODO: REMOVE - testing if multidev catches PHP 8.5 deprecation.
-$_test_deprecation = (integer) 1;
-
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;


### PR DESCRIPTION
## Summary

- Add PHP >= 8.2 requirement to composer.json
- Align CI workflow with shared Drupal module template (search_api_pantheon PR #262)
- Replace manual Terminus curl install with terminus-github-actions (SHA-pinned)
- Extract multidev naming and constraint derivation to set-multidev-and-constraint.sh
- Centralize all env vars in job-level env block, reference via env vars not secrets/matrix directly
- Update Terminus version threshold from >= 8.4 to >= 8.2 (T4 dropped < 8.2)
- Add two-pass cleanup: success-only delete current multidev + 72h age-based sweep for orphans
- Show multidev URL only on failure (retained env for investigation)
- Update all actions to latest SHA-pinned versions (checkout v6.0.2, setup-php v2.37.0, cache v5.0.5, phpcompatibility v1.1.2, ssh-agent v0.10.0)
- Linting matrix: PHP 8.2 + 8.5 (floor + ceiling)
- Deploy-multidev matrix: D10 PHP 8.2+8.4, D11 PHP 8.3+8.5 (4 jobs)
- Update README to note PHP 8.5 compatibility

## Context

[SITE-5203](https://getpantheon.atlassian.net/browse/SITE-5203)

PHP 8.5 compatibility for Pantheon Content Publisher Drupal module (SITE-5195 epic). All 54 PHP files audited with PHPCompatibility v10: zero deprecation issues. Module already compatible. No code fixes needed.

CI alignment follows the shared template established in search_api_pantheon PR #262 (SITE-5198). All three Drupal modules (search_api_pantheon, PAPC, Content Publisher) now use the same CI conventions: terminus-github-actions, env var centralization, two-pass cleanup, constraint derivation, and multidev naming.

PHPCompatibility `test-versions: 8.2-` unchanged. Underlying v9.3 lacks 8.5-specific sniffs; upstream limitation until `phpcompatibility-action` upgrades to v10.

## Test plan

- [ ] PHP 8.2 + 8.5 linting jobs pass (code:lint + codesniff)
- [ ] PHPCompatibility job passes
- [ ] Deploy-multidev jobs pass for all 4 combos (D10+8.2, D10+8.4, D11+8.3, D11+8.5)
- [ ] "Show PHP versions" step confirms runner and multidev PHP match
- [ ] On success: current multidev is deleted
- [ ] On failure: multidev URL is shown, env retained for investigation
- [ ] Cleanup script removes stale multidevs (prefix match + 72h age sweep)
- [ ] Update drupal.org project page post-merge

## References

- Jira: [SITE-5203](https://getpantheon.atlassian.net/browse/SITE-5203)
- Template PR: [search_api_pantheon #262](https://github.com/pantheon-systems/search_api_pantheon/pull/262)
- PHP 8.5 changes: https://php.watch/versions/8.5
- Related: SITE-5197 (PAPC Drupal, same pattern)

[SITE-5203]: https://getpantheon.atlassian.net/browse/SITE-5203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SITE-5203]: https://getpantheon.atlassian.net/browse/SITE-5203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ