### PR TITLE
[SITE-5881] Fix queue race condition and stale search cache after publish

### DIFF
--- a/pantheon_content_publisher.services.yml
+++ b/pantheon_content_publisher.services.yml
@@ -27,3 +27,8 @@ services:
     autowire: TRUE
     tags:
       - { name: event_subscriber }
+  pantheon_content_publisher.solr_cache_reinvalidator:
+    class: Drupal\pantheon_content_publisher\EventSubscriber\SolrCacheReInvalidator
+    arguments: ['@state']
+    tags:
+      - { name: event_subscriber }

--- a/src/EventSubscriber/QueueRunner.php
+++ b/src/EventSubscriber/QueueRunner.php
@@ -22,6 +22,10 @@ class QueueRunner implements EventSubscriberInterface {
     if (!file_exists($drush)) {
       return;
     }
+    // Allow Content Cloud API time to propagate the document before
+    // the queue worker tries to load it. This runs after the HTTP
+    // response has been sent (TERMINATE event), so no user-facing impact.
+    sleep(5);
     $process = new Process([$drush, 'queue-run', 'pantheon_content_publisher_entity']);
     $process->setTimeout(0);
     $process->run();

--- a/src/EventSubscriber/SolrCacheReInvalidator.php
+++ b/src/EventSubscriber/SolrCacheReInvalidator.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\pantheon_content_publisher\EventSubscriber;
+
+use Drupal\Core\Cache\Cache;
+use Drupal\Core\State\StateInterface;
+use Drupal\search_api\Event\ItemsIndexedEvent;
+use Drupal\search_api\Event\SearchApiEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Re-invalidates Search API cache tags after Solr commits.
+ *
+ * Solr's autoSoftCommit (5s on Pantheon) means search results aren't
+ * visible immediately after indexing. If a visitor request arrives in
+ * that window, stale Solr results get cached. This subscriber fires a
+ * second invalidation after the commit window closes.
+ *
+ * Also directly purges the CDN using the PAPC-renamed tag variant,
+ * working around the _list → _emit_list Surrogate-Key mismatch.
+ */
+class SolrCacheReInvalidator implements EventSubscriberInterface {
+
+  const SOLR_COMMIT_BUFFER_SECONDS = 6;
+
+  public function __construct(
+    protected StateInterface $state,
+  ) {}
+
+  public function onItemsIndexed(ItemsIndexedEvent $event): void {
+    $index_id = $event->getIndex()->id();
+    $this->state->set('pantheon_cp.cdn_purge_due', [
+      'time' => time() + self::SOLR_COMMIT_BUFFER_SECONDS,
+      'index_id' => $index_id,
+    ]);
+  }
+
+  public function onRequest(RequestEvent $event): void {
+    if (!$event->isMainRequest()) {
+      return;
+    }
+
+    $purge = $this->state->get('pantheon_cp.cdn_purge_due');
+    if (!$purge || time() < $purge['time']) {
+      return;
+    }
+
+    $this->state->delete('pantheon_cp.cdn_purge_due');
+    $index_id = $purge['index_id'];
+
+    // Re-invalidate Drupal's internal caches (page_cache, dynamic_page_cache).
+    // Uses the original tag name which internal caches store unchanged.
+    Cache::invalidateTags(["search_api_list:$index_id"]);
+
+    // Purge CDN with the PAPC-renamed tag. PAPC's override_list_tags
+    // renames _list → _emit_list in Surrogate-Key headers, but the
+    // normal invalidation chain sends the original name. This call
+    // sends the renamed variant so the CDN actually purges.
+    if (function_exists('pantheon_clear_edge_keys')) {
+      pantheon_clear_edge_keys(["search_api_emit_list:$index_id"]);
+    }
+  }
+
+  public static function getSubscribedEvents(): array {
+    return [
+      SearchApiEvents::ITEMS_INDEXED => 'onItemsIndexed',
+      KernelEvents::REQUEST => ['onRequest', 100],
+    ];
+  }
+
+}

--- a/src/EventSubscriber/SolrCacheReInvalidator.php
+++ b/src/EventSubscriber/SolrCacheReInvalidator.php
@@ -33,10 +33,9 @@ class SolrCacheReInvalidator implements EventSubscriberInterface {
 
   public function onItemsIndexed(ItemsIndexedEvent $event): void {
     $index_id = $event->getIndex()->id();
-    $this->state->set('pantheon_cp.cdn_purge_due', [
-      'time' => time() + self::SOLR_COMMIT_BUFFER_SECONDS,
-      'index_id' => $index_id,
-    ]);
+    $pending = $this->state->get('pantheon_cp.cdn_purge_due', []);
+    $pending[$index_id] = time() + self::SOLR_COMMIT_BUFFER_SECONDS;
+    $this->state->set('pantheon_cp.cdn_purge_due', $pending);
   }
 
   public function onRequest(RequestEvent $event): void {
@@ -44,24 +43,33 @@ class SolrCacheReInvalidator implements EventSubscriberInterface {
       return;
     }
 
-    $purge = $this->state->get('pantheon_cp.cdn_purge_due');
-    if (!$purge || time() < $purge['time']) {
+    $pending = $this->state->get('pantheon_cp.cdn_purge_due', []);
+    if (empty($pending)) {
       return;
     }
 
-    $this->state->delete('pantheon_cp.cdn_purge_due');
-    $index_id = $purge['index_id'];
+    $now = time();
+    $due = array_filter($pending, fn($time) => $now >= $time);
+    if (empty($due)) {
+      return;
+    }
 
-    // Re-invalidate Drupal's internal caches (page_cache, dynamic_page_cache).
-    // Uses the original tag name which internal caches store unchanged.
-    Cache::invalidateTags(["search_api_list:$index_id"]);
+    $remaining = array_diff_key($pending, $due);
+    empty($remaining)
+      ? $this->state->delete('pantheon_cp.cdn_purge_due')
+      : $this->state->set('pantheon_cp.cdn_purge_due', $remaining);
 
-    // Purge CDN with the PAPC-renamed tag. PAPC's override_list_tags
-    // renames _list → _emit_list in Surrogate-Key headers, but the
-    // normal invalidation chain sends the original name. This call
-    // sends the renamed variant so the CDN actually purges.
+    $tags = [];
+    $edge_keys = [];
+    foreach (array_keys($due) as $index_id) {
+      $tags[] = "search_api_list:$index_id";
+      $edge_keys[] = "search_api_emit_list:$index_id";
+    }
+
+    Cache::invalidateTags($tags);
+
     if (function_exists('pantheon_clear_edge_keys')) {
-      pantheon_clear_edge_keys(["search_api_emit_list:$index_id"]);
+      pantheon_clear_edge_keys($edge_keys);
     }
   }
 

--- a/src/Plugin/QueueWorker/EntityQueueWorker.php
+++ b/src/Plugin/QueueWorker/EntityQueueWorker.php
@@ -8,7 +8,9 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\KeyValueStore\KeyValueFactoryInterface;
 use Drupal\Core\KeyValueStore\KeyValueStoreInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Queue\DelayedRequeueException;
 use Drupal\Core\Queue\QueueWorkerBase;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -22,7 +24,11 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class EntityQueueWorker extends QueueWorkerBase implements ContainerFactoryPluginInterface {
 
+  const MAX_RETRIES = 3;
+  const RETRY_DELAY = 15;
+
   protected KeyValueStoreInterface $seenStore;
+  protected KeyValueStoreInterface $retryStore;
 
   public function __construct(
     array $configuration,
@@ -30,8 +36,10 @@ class EntityQueueWorker extends QueueWorkerBase implements ContainerFactoryPlugi
     $plugin_definition,
     protected EntityTypeManagerInterface $entityTypeManager,
     KeyValueFactoryInterface $keyValueFactory,
+    protected LoggerInterface $logger,
   ) {
     $this->seenStore = $keyValueFactory->get('pantheon_document.seen');
+    $this->retryStore = $keyValueFactory->get('pantheon_content_publisher.queue_retries');
     parent::__construct($configuration, $plugin_id, $plugin_definition);
   }
 
@@ -44,7 +52,8 @@ class EntityQueueWorker extends QueueWorkerBase implements ContainerFactoryPlugi
       $plugin_id,
       $plugin_definition,
       $container->get('entity_type.manager'),
-      $container->get('keyvalue')
+      $container->get('keyvalue'),
+      $container->get('logger.factory')->get('pantheon_content_publisher'),
     );
   }
 
@@ -53,10 +62,16 @@ class EntityQueueWorker extends QueueWorkerBase implements ContainerFactoryPlugi
    */
   public function processItem($data): void {
     $entity_type_id = $data['entity_type'];
+    $entity_id = $data['entity_id'];
     $storage = $this->entityTypeManager->getStorage($entity_type_id);
 
     if (empty($data['delete'])) {
-      $entity = $storage->load($data['entity_id']);
+      $entity = $storage->load($entity_id);
+      if ($entity === NULL) {
+        $this->handleLoadFailure($entity_id);
+        return;
+      }
+      $this->retryStore->delete($entity_id);
       if ($this->seenStore->setIfNotExists($entity->id(), 1)) {
         (new \ReflectionObject($storage))
           ->getMethod('invokeHook')
@@ -68,12 +83,34 @@ class EntityQueueWorker extends QueueWorkerBase implements ContainerFactoryPlugi
       $entityType = $this->entityTypeManager->getDefinition($entity_type_id);
       $entity = $storage->create([
         $entityType->getKey('bundle') => $data['bundle'],
-        $entityType->getKey('id') => $data['entity_id'],
+        $entityType->getKey('id') => $entity_id,
       ]);
       $entity->enforceIsNew(FALSE);
       $entity->delete();
       $this->seenStore->delete($entity->id());
     }
+  }
+
+  protected function handleLoadFailure(string $entity_id): void {
+    $retries = (int) $this->retryStore->get($entity_id, 0);
+
+    if ($retries >= self::MAX_RETRIES) {
+      $this->logger->error('Entity %id not available from Content Cloud API after @max attempts. Discarding queue item.', [
+        '%id' => $entity_id,
+        '@max' => self::MAX_RETRIES,
+      ]);
+      $this->retryStore->delete($entity_id);
+      return;
+    }
+
+    $this->retryStore->set($entity_id, $retries + 1);
+    $this->logger->warning('Entity %id not yet available from Content Cloud API (attempt @attempt/@max). Requeuing with @delay second delay.', [
+      '%id' => $entity_id,
+      '@attempt' => $retries + 1,
+      '@max' => self::MAX_RETRIES,
+      '@delay' => self::RETRY_DELAY,
+    ]);
+    throw new DelayedRequeueException(self::RETRY_DELAY);
   }
 
 }

--- a/tests/src/Unit/EntityQueueWorkerTest.php
+++ b/tests/src/Unit/EntityQueueWorkerTest.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\pantheon_content_publisher\Unit;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\ContentEntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\KeyValueStore\KeyValueFactoryInterface;
+use Drupal\Core\KeyValueStore\KeyValueStoreInterface;
+use Drupal\Core\Queue\DelayedRequeueException;
+use Drupal\pantheon_content_publisher\PantheonDocumentStorage;
+use Drupal\pantheon_content_publisher\Plugin\QueueWorker\EntityQueueWorker;
+use Drupal\Tests\UnitTestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @group pantheon_content_publisher
+ * @coversDefaultClass \Drupal\pantheon_content_publisher\Plugin\QueueWorker\EntityQueueWorker
+ */
+class EntityQueueWorkerTest extends UnitTestCase {
+
+  protected EntityTypeManagerInterface $entityTypeManager;
+  protected KeyValueStoreInterface $seenStore;
+  protected KeyValueStoreInterface $retryStore;
+  protected LoggerInterface $logger;
+  protected EntityQueueWorker $worker;
+
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->entityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
+    $this->seenStore = $this->createMock(KeyValueStoreInterface::class);
+    $this->retryStore = $this->createMock(KeyValueStoreInterface::class);
+    $this->logger = $this->createMock(LoggerInterface::class);
+
+    $keyValueFactory = $this->createMock(KeyValueFactoryInterface::class);
+    $keyValueFactory->method('get')
+      ->willReturnMap([
+        ['pantheon_document.seen', $this->seenStore],
+        ['pantheon_content_publisher.queue_retries', $this->retryStore],
+      ]);
+
+    $this->worker = new EntityQueueWorker(
+      [],
+      'pantheon_content_publisher_entity',
+      ['cron' => ['time' => 60]],
+      $this->entityTypeManager,
+      $keyValueFactory,
+      $this->logger,
+    );
+  }
+
+  /**
+   * @covers ::processItem
+   */
+  public function testProcessItemSavesEntity(): void {
+    $entity = $this->createMock(ContentEntityInterface::class);
+    $entity->method('id')->willReturn('collection.doc-1');
+
+    $storage = $this->createMock(ContentEntityStorageInterface::class);
+    $storage->expects($this->once())
+      ->method('load')
+      ->with('collection.doc-1')
+      ->willReturn($entity);
+
+    $this->entityTypeManager->method('getStorage')
+      ->with('pantheon_document')
+      ->willReturn($storage);
+
+    $this->seenStore->method('setIfNotExists')->willReturn(FALSE);
+    $this->retryStore->expects($this->once())
+      ->method('delete')
+      ->with('collection.doc-1');
+
+    $entity->expects($this->once())->method('save');
+
+    $this->worker->processItem([
+      'entity_type' => 'pantheon_document',
+      'entity_id' => 'collection.doc-1',
+    ]);
+  }
+
+  /**
+   * @covers ::processItem
+   */
+  public function testProcessItemInvokesInsertHookForNewEntity(): void {
+    $entity = $this->createMock(ContentEntityInterface::class);
+    $entity->method('id')->willReturn('collection.doc-new');
+
+    $storage = $this->getMockBuilder(PantheonDocumentStorage::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['load', 'invokeHook'])
+      ->getMock();
+    $storage->method('load')->willReturn($entity);
+    $storage->expects($this->once())
+      ->method('invokeHook')
+      ->with('insert', $entity);
+
+    $this->entityTypeManager->method('getStorage')->willReturn($storage);
+
+    $this->seenStore->expects($this->once())
+      ->method('setIfNotExists')
+      ->with('collection.doc-new', 1)
+      ->willReturn(TRUE);
+
+    $this->retryStore->expects($this->once())
+      ->method('delete')
+      ->with('collection.doc-new');
+
+    $entity->expects($this->once())->method('save');
+
+    $this->worker->processItem([
+      'entity_type' => 'pantheon_document',
+      'entity_id' => 'collection.doc-new',
+    ]);
+  }
+
+  /**
+   * @covers ::processItem
+   */
+  public function testProcessItemRequeuesOnNullEntity(): void {
+    $storage = $this->createMock(ContentEntityStorageInterface::class);
+    $storage->method('load')->willReturn(NULL);
+
+    $this->entityTypeManager->method('getStorage')->willReturn($storage);
+
+    $this->retryStore->method('get')
+      ->with('collection.doc-1', 0)
+      ->willReturn(0);
+    $this->retryStore->expects($this->once())
+      ->method('set')
+      ->with('collection.doc-1', 1);
+
+    $this->logger->expects($this->once())
+      ->method('warning')
+      ->with(
+        $this->stringContains('not yet available'),
+        $this->callback(fn($ctx) => $ctx['%id'] === 'collection.doc-1' && $ctx['@attempt'] === 1),
+      );
+
+    $this->expectException(DelayedRequeueException::class);
+
+    $this->worker->processItem([
+      'entity_type' => 'pantheon_document',
+      'entity_id' => 'collection.doc-1',
+    ]);
+  }
+
+  /**
+   * @covers ::processItem
+   */
+  public function testProcessItemDiscardsAfterMaxRetries(): void {
+    $storage = $this->createMock(ContentEntityStorageInterface::class);
+    $storage->method('load')->willReturn(NULL);
+
+    $this->entityTypeManager->method('getStorage')->willReturn($storage);
+
+    $this->retryStore->method('get')
+      ->with('collection.doc-1', 0)
+      ->willReturn(3);
+    $this->retryStore->expects($this->once())
+      ->method('delete')
+      ->with('collection.doc-1');
+
+    $this->logger->expects($this->once())
+      ->method('error')
+      ->with(
+        $this->stringContains('not available'),
+        $this->callback(fn($ctx) => $ctx['%id'] === 'collection.doc-1' && $ctx['@max'] === 3),
+      );
+
+    $this->worker->processItem([
+      'entity_type' => 'pantheon_document',
+      'entity_id' => 'collection.doc-1',
+    ]);
+  }
+
+  /**
+   * @covers ::processItem
+   */
+  public function testProcessItemDeletePath(): void {
+    $entity = $this->createMock(ContentEntityInterface::class);
+    $entity->method('id')->willReturn('collection.doc-del');
+
+    $entityType = $this->createMock(EntityTypeInterface::class);
+    $entityType->method('getKey')
+      ->willReturnMap([
+        ['bundle', 'type'],
+        ['id', 'id'],
+      ]);
+
+    $storage = $this->createMock(ContentEntityStorageInterface::class);
+    $storage->expects($this->once())
+      ->method('create')
+      ->with(['type' => 'article', 'id' => 'collection.doc-del'])
+      ->willReturn($entity);
+
+    $this->entityTypeManager->method('getStorage')->willReturn($storage);
+    $this->entityTypeManager->method('getDefinition')
+      ->with('pantheon_document')
+      ->willReturn($entityType);
+
+    $entity->expects($this->once())->method('enforceIsNew')->with(FALSE);
+    $entity->expects($this->once())->method('delete');
+
+    $this->seenStore->expects($this->once())
+      ->method('delete')
+      ->with('collection.doc-del');
+
+    $this->worker->processItem([
+      'entity_type' => 'pantheon_document',
+      'entity_id' => 'collection.doc-del',
+      'bundle' => 'article',
+      'delete' => TRUE,
+    ]);
+  }
+
+  /**
+   * @covers ::processItem
+   */
+  public function testRetryCountResetsOnSuccess(): void {
+    $entity = $this->createMock(ContentEntityInterface::class);
+    $entity->method('id')->willReturn('collection.doc-retry');
+
+    $storage = $this->createMock(ContentEntityStorageInterface::class);
+    $storage->method('load')->willReturn($entity);
+
+    $this->entityTypeManager->method('getStorage')->willReturn($storage);
+    $this->seenStore->method('setIfNotExists')->willReturn(FALSE);
+
+    $this->retryStore->expects($this->once())
+      ->method('delete')
+      ->with('collection.doc-retry');
+
+    $this->worker->processItem([
+      'entity_type' => 'pantheon_document',
+      'entity_id' => 'collection.doc-retry',
+    ]);
+  }
+
+}

--- a/tests/src/Unit/SolrCacheReInvalidatorTest.php
+++ b/tests/src/Unit/SolrCacheReInvalidatorTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\pantheon_content_publisher\Unit;
+
+use Drupal\Core\State\StateInterface;
+use Drupal\pantheon_content_publisher\EventSubscriber\SolrCacheReInvalidator;
+use Drupal\search_api\Event\ItemsIndexedEvent;
+use Drupal\search_api\Event\SearchApiEvents;
+use Drupal\search_api\IndexInterface;
+use Drupal\Tests\UnitTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * @group pantheon_content_publisher
+ * @coversDefaultClass \Drupal\pantheon_content_publisher\EventSubscriber\SolrCacheReInvalidator
+ */
+class SolrCacheReInvalidatorTest extends UnitTestCase {
+
+  protected StateInterface $state;
+  protected SolrCacheReInvalidator $subscriber;
+
+  protected function setUp(): void {
+    parent::setUp();
+    $this->state = $this->createMock(StateInterface::class);
+    $this->subscriber = new SolrCacheReInvalidator($this->state);
+  }
+
+  /**
+   * @covers ::getSubscribedEvents
+   */
+  public function testSubscribedEvents(): void {
+    $events = SolrCacheReInvalidator::getSubscribedEvents();
+    $this->assertArrayHasKey(SearchApiEvents::ITEMS_INDEXED, $events);
+    $this->assertArrayHasKey(KernelEvents::REQUEST, $events);
+  }
+
+  /**
+   * @covers ::onItemsIndexed
+   */
+  public function testOnItemsIndexedSchedulesPurge(): void {
+    $index = $this->createMock(IndexInterface::class);
+    $index->method('id')->willReturn('primary');
+    $event = new ItemsIndexedEvent($index, ['item-1']);
+
+    $this->state->expects($this->once())
+      ->method('set')
+      ->with(
+        'pantheon_cp.cdn_purge_due',
+        $this->callback(function ($value) {
+          return $value['index_id'] === 'primary'
+            && $value['time'] >= time() + 5
+            && $value['time'] <= time() + 7;
+        }),
+      );
+
+    $this->subscriber->onItemsIndexed($event);
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testOnRequestSkipsWhenNoPurgePending(): void {
+    $this->state->method('get')
+      ->with('pantheon_cp.cdn_purge_due')
+      ->willReturn(NULL);
+
+    $this->state->expects($this->never())->method('delete');
+
+    $event = $this->createRequestEvent();
+    $this->subscriber->onRequest($event);
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testOnRequestSkipsWhenNotYetDue(): void {
+    $this->state->method('get')
+      ->with('pantheon_cp.cdn_purge_due')
+      ->willReturn(['time' => time() + 60, 'index_id' => 'primary']);
+
+    $this->state->expects($this->never())->method('delete');
+
+    $event = $this->createRequestEvent();
+    $this->subscriber->onRequest($event);
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testOnRequestFiresWhenDue(): void {
+    $this->state->method('get')
+      ->with('pantheon_cp.cdn_purge_due')
+      ->willReturn(['time' => time() - 1, 'index_id' => 'primary']);
+
+    $this->state->expects($this->once())
+      ->method('delete')
+      ->with('pantheon_cp.cdn_purge_due');
+
+    $event = $this->createRequestEvent();
+    $this->subscriber->onRequest($event);
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testOnRequestSkipsSubRequests(): void {
+    $this->state->expects($this->never())->method('get');
+
+    $event = $this->createRequestEvent(HttpKernelInterface::SUB_REQUEST);
+    $this->subscriber->onRequest($event);
+  }
+
+  protected function createRequestEvent(int $type = HttpKernelInterface::MAIN_REQUEST): RequestEvent {
+    $kernel = $this->createMock(HttpKernelInterface::class);
+    return new RequestEvent($kernel, new Request(), $type);
+  }
+
+}

--- a/tests/src/Unit/SolrCacheReInvalidatorTest.php
+++ b/tests/src/Unit/SolrCacheReInvalidatorTest.php
@@ -47,14 +47,44 @@ class SolrCacheReInvalidatorTest extends UnitTestCase {
     $index->method('id')->willReturn('primary');
     $event = new ItemsIndexedEvent($index, ['item-1']);
 
+    $this->state->method('get')
+      ->with('pantheon_cp.cdn_purge_due', [])
+      ->willReturn([]);
+
     $this->state->expects($this->once())
       ->method('set')
       ->with(
         'pantheon_cp.cdn_purge_due',
         $this->callback(function ($value) {
-          return $value['index_id'] === 'primary'
-            && $value['time'] >= time() + 5
-            && $value['time'] <= time() + 7;
+          return isset($value['primary'])
+            && $value['primary'] >= time() + 5
+            && $value['primary'] <= time() + 7;
+        }),
+      );
+
+    $this->subscriber->onItemsIndexed($event);
+  }
+
+  /**
+   * @covers ::onItemsIndexed
+   */
+  public function testOnItemsIndexedPreservesExistingIndexes(): void {
+    $index = $this->createMock(IndexInterface::class);
+    $index->method('id')->willReturn('secondary');
+    $event = new ItemsIndexedEvent($index, ['item-1']);
+
+    $existing = ['primary' => time() + 10];
+    $this->state->method('get')
+      ->with('pantheon_cp.cdn_purge_due', [])
+      ->willReturn($existing);
+
+    $this->state->expects($this->once())
+      ->method('set')
+      ->with(
+        'pantheon_cp.cdn_purge_due',
+        $this->callback(function ($value) use ($existing) {
+          return isset($value['primary'], $value['secondary'])
+            && $value['primary'] === $existing['primary'];
         }),
       );
 
@@ -66,8 +96,8 @@ class SolrCacheReInvalidatorTest extends UnitTestCase {
    */
   public function testOnRequestSkipsWhenNoPurgePending(): void {
     $this->state->method('get')
-      ->with('pantheon_cp.cdn_purge_due')
-      ->willReturn(NULL);
+      ->with('pantheon_cp.cdn_purge_due', [])
+      ->willReturn([]);
 
     $this->state->expects($this->never())->method('delete');
 
@@ -80,8 +110,8 @@ class SolrCacheReInvalidatorTest extends UnitTestCase {
    */
   public function testOnRequestSkipsWhenNotYetDue(): void {
     $this->state->method('get')
-      ->with('pantheon_cp.cdn_purge_due')
-      ->willReturn(['time' => time() + 60, 'index_id' => 'primary']);
+      ->with('pantheon_cp.cdn_purge_due', [])
+      ->willReturn(['primary' => time() + 60]);
 
     $this->state->expects($this->never())->method('delete');
 
@@ -94,12 +124,36 @@ class SolrCacheReInvalidatorTest extends UnitTestCase {
    */
   public function testOnRequestFiresWhenDue(): void {
     $this->state->method('get')
-      ->with('pantheon_cp.cdn_purge_due')
-      ->willReturn(['time' => time() - 1, 'index_id' => 'primary']);
+      ->with('pantheon_cp.cdn_purge_due', [])
+      ->willReturn(['primary' => time() - 1]);
 
     $this->state->expects($this->once())
       ->method('delete')
       ->with('pantheon_cp.cdn_purge_due');
+
+    $event = $this->createRequestEvent();
+    $this->subscriber->onRequest($event);
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testOnRequestPurgesOnlyDueIndexes(): void {
+    $this->state->method('get')
+      ->with('pantheon_cp.cdn_purge_due', [])
+      ->willReturn([
+        'primary' => time() - 1,
+        'secondary' => time() + 60,
+      ]);
+
+    $this->state->expects($this->once())
+      ->method('set')
+      ->with(
+        'pantheon_cp.cdn_purge_due',
+        $this->callback(fn($v) => isset($v['secondary']) && !isset($v['primary'])),
+      );
+
+    $this->state->expects($this->never())->method('delete');
 
     $event = $this->createRequestEvent();
     $this->subscriber->onRequest($event);


### PR DESCRIPTION
## Summary

- **Queue race condition**: Content Cloud API hasn't propagated the document by the time the queue worker runs, causing entity load failures. Added 5s delay before queue-run (in TERMINATE, no user impact) and retry logic with `DelayedRequeueException` (3 attempts, 15s delay).
- **Stale search cache**: Solr's `autoSoftCommit` (5s on Pantheon) creates a window where a visitor request caches stale results. `SolrCacheReInvalidator` re-invalidates cache tags after the commit window and directly purges CDN with the PAPC-renamed tag variant (`_emit_list`), working around the Surrogate-Key mismatch. Temporary fix until the proper fix lands in PAPC/search_api_pantheon (SITE-6015).

## Test plan

- [ ] Publish a document in Content Publisher and verify it appears on the site without manual cache clear
- [ ] Verify queue worker retries on API propagation delay (check logs for requeue warnings)
- [ ] Verify search listing pages update within ~10s of publish (not stuck until TTL expires)
- [ ] Confirm no regressions on existing entity save/delete flows