### PR TITLE
[SITE-6002] Fix CodeQL alerts

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -21,11 +21,11 @@ jobs:
       DRUPAL_ORG_REMOTE: ${{ secrets.DRUPAL_ORG_REMOTE }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
       - name: Install SSH key
-        uses: shimataro/ssh-key-action@v2
+        uses: shimataro/ssh-key-action@87a8f067114a8ce263df83e9ed5c849953548bc3 # v2.8.1
         with:
           key: ${{ secrets.PANTHEON_PLATFORM_DEPLOY_KEY_PRIVATE }}
           known_hosts: ${{ secrets.KNOWN_HOSTS }}


### PR DESCRIPTION
## Summary

Pins GitHub Actions in the mirror workflow to their commit SHAs instead of mutable version tags. This prevents supply-chain attacks where a compromised tag could point to malicious code. Resolves the CodeQL `unpinned-tag` alert.

Changes:
- `actions/checkout@v5` pinned to `93cb6efe` (v5.0.1)
- `shimataro/ssh-key-action@v2` pinned to `87a8f067` (v2.8.1)

## Test plan

- [ ] Verify the mirror workflow still works on push
- [ ] Confirm CodeQL alert is resolved