### PR TITLE
[SITE-5852] Fix CI linting failure  by adding symfony/runtime to allow-plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,8 @@
         "allow-plugins": {
             "composer/installers": true,
             "drupal/core-composer-scaffold": true,
-            "dealerdirect/phpcodesniffer-composer-installer": true
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "symfony/runtime": true
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds `symfony/runtime: true` to `allow-plugins` in `composer.json` to fix the CI linting job failure
- Drupal core 11.4+ introduced `symfony/runtime` as a transitive Composer plugin dependency, which is blocked without an explicit allowlist entry
